### PR TITLE
feat: adds no-effect-decorator rule

### DIFF
--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -7,6 +7,7 @@
     "ngrx/no-typed-store": "error",
     "ngrx/avoid-dispatching-multiple-actions-sequentially": "error",
     "ngrx/no-multiple-stores": "error",
-    "ngrx/no-dispatch-in-effects": "error"
+    "ngrx/no-dispatch-in-effects": "error",
+    "ngrx/no-effect-decorator": "error"
   }
 }

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -19,6 +19,9 @@ import noMultipleStores, {
 import noDispatchInEffects, {
   ruleName as noDispatchInEffectsRuleName,
 } from './no-dispatch-in-effects'
+import noEffectDecorator, {
+  ruleName as noEffectDecoratorRuleName,
+} from './no-effect-decorator'
 
 const ruleNames = {
   actionHygieneRuleName,
@@ -28,6 +31,7 @@ const ruleNames = {
   avoidDispatchingMultipleActionsSequentiallyRuleName,
   noMultipleStoresRuleName,
   noDispatchInEffectsRuleName,
+  noEffectDecoratorRuleName,
 }
 
 export const rules = {
@@ -38,4 +42,5 @@ export const rules = {
   [ruleNames.avoidDispatchingMultipleActionsSequentiallyRuleName]: avoidDispatchingMultipleActionsSequentially,
   [ruleNames.noMultipleStoresRuleName]: noMultipleStores,
   [ruleNames.noDispatchInEffectsRuleName]: noDispatchInEffects,
+  [ruleNames.noEffectDecoratorRuleName]: noEffectDecorator,
 }

--- a/src/rules/no-effect-decorator.ts
+++ b/src/rules/no-effect-decorator.ts
@@ -1,0 +1,38 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+
+import { effectDecorator } from './utils'
+
+export const ruleName = 'no-effect-decorator'
+
+export const messageId = 'noEffectDecorator'
+export type MessageIds = typeof messageId
+
+type Options = []
+
+export default ESLintUtils.RuleCreator(name => name)<Options, MessageIds>({
+  name: ruleName,
+  meta: {
+    type: 'problem',
+    docs: {
+      category: 'Possible Errors',
+      description: 'The createEffect creator function is preferred',
+      extraDescription: ['createEffect allows an effect to be type safe'],
+      recommended: 'error',
+    },
+    schema: [],
+    messages: {
+      [messageId]: 'The createEffect creator function is preferred.',
+    },
+  },
+  defaultOptions: [],
+  create: context => {
+    return {
+      [effectDecorator](node: TSESTree.TSTypeReference) {
+        context.report({
+          node,
+          messageId,
+        })
+      },
+    }
+  },
+})

--- a/tests/rules/no-effect-decorator.test.ts
+++ b/tests/rules/no-effect-decorator.test.ts
@@ -1,0 +1,65 @@
+import { stripIndent } from 'common-tags'
+import rule, { ruleName, messageId } from '../../src/rules/no-effect-decorator'
+import { ruleTester } from '../utils'
+
+ruleTester().run(ruleName, rule, {
+  valid: [
+    `
+    @Injectable()
+export class FixtureEffects {
+
+  effectOK = createEffect(() => this.actions.pipe(
+    ofType('PING'),
+    map(() => ({ type: 'PONG' }))
+  ))
+
+  constructor(private actions: Actions){}
+}`,
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+      @Injectable()
+      export class FixtureEffects {
+        @Effect()
+        effectNOK =  this.actions.pipe(
+          ofType('PING'),
+          map(() => ({ type: 'PONG' }))
+        )
+
+        constructor(private actions: Actions){}
+      }`,
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 3,
+          endLine: 3,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+      @Injectable()
+      export class FixtureEffects {
+        @Effect({ dispatch: false })
+        effectNOK2 = this.actions.pipe(
+          ofType('PING'),
+          map(() => ({ type: 'PONG' }))
+        )
+
+        constructor(private actions: Actions){}
+      }`,
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 3,
+          endLine: 3,
+          endColumn: 31,
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
I put this one as an error whereas it is only a warning in ngrx-tslint-rule.
createEffect has been introduced 2 versions ago in NGRX (if I'm not mistaken) so I believe it is ok to put it as an error.
Users can still override the recommended config and put it as a warning if needed.

If you believe it should stay a warning, I can switch it back.