### PR TITLE
feat: adds no-effects-in-providers rule

### DIFF
--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -8,6 +8,7 @@
     "ngrx/avoid-dispatching-multiple-actions-sequentially": "error",
     "ngrx/no-multiple-stores": "error",
     "ngrx/no-dispatch-in-effects": "error",
-    "ngrx/no-effect-decorator": "error"
+    "ngrx/no-effect-decorator": "error",
+    "ngrx/no-effects-in-providers": "error"
   }
 }

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -22,6 +22,9 @@ import noDispatchInEffects, {
 import noEffectDecorator, {
   ruleName as noEffectDecoratorRuleName,
 } from './no-effect-decorator'
+import noEffectsInProviders, {
+  ruleName as noEffectsInProvidersRuleName,
+} from './no-effects-in-providers'
 
 const ruleNames = {
   actionHygieneRuleName,
@@ -32,6 +35,7 @@ const ruleNames = {
   noMultipleStoresRuleName,
   noDispatchInEffectsRuleName,
   noEffectDecoratorRuleName,
+  noEffectsInProvidersRuleName,
 }
 
 export const rules = {
@@ -43,4 +47,5 @@ export const rules = {
   [ruleNames.noMultipleStoresRuleName]: noMultipleStores,
   [ruleNames.noDispatchInEffectsRuleName]: noDispatchInEffects,
   [ruleNames.noEffectDecoratorRuleName]: noEffectDecorator,
+  [ruleNames.noEffectsInProvidersRuleName]: noEffectsInProviders,
 }

--- a/src/rules/no-effects-in-providers.ts
+++ b/src/rules/no-effects-in-providers.ts
@@ -1,0 +1,59 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+
+import {
+  ngModuleDecorator,
+  ngModuleImports,
+  ngModuleProviders,
+} from './utils/selectors'
+
+export const ruleName = 'no-effects-in-providers'
+
+export const messageId = 'noEffectsInProviders'
+export type MessageIds = typeof messageId
+
+type Options = []
+
+export default ESLintUtils.RuleCreator(name => name)<Options, MessageIds>({
+  name: ruleName,
+  meta: {
+    type: 'problem',
+    docs: {
+      category: 'Possible Errors',
+      description:
+        'An Effect should not be listed as a provider if it is added to the EffectsModule',
+      extraDescription: [
+        'If an Effect is registered with EffectsModule and is added as a provider, it will be registered twice',
+      ],
+      recommended: 'error',
+    },
+    schema: [],
+    messages: {
+      [messageId]:
+        'The Effect should not be listed as a provider if it is added to the EffectsModule',
+    },
+  },
+  defaultOptions: [],
+  create: context => {
+    const effectsInProviders: TSESTree.Identifier[] = []
+    const importedEffectsNames: string[] = []
+
+    return {
+      [ngModuleProviders](node: TSESTree.Identifier) {
+        effectsInProviders.push(node)
+      },
+      [ngModuleImports](node: TSESTree.Identifier) {
+        importedEffectsNames.push(node.name)
+      },
+      [`${ngModuleDecorator}:exit`]() {
+        effectsInProviders.forEach((effect: TSESTree.Identifier) => {
+          if (importedEffectsNames.includes(effect.name)) {
+            context.report({
+              node: effect,
+              messageId,
+            })
+          }
+        })
+      },
+    }
+  },
+})

--- a/src/rules/utils/selectors/index.ts
+++ b/src/rules/utils/selectors/index.ts
@@ -17,3 +17,9 @@ export const dispatchInEffects = `ClassProperty > CallExpression:has(Identifier[
 export const injectedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name="Store"]`
 
 export const typedStore = `${injectedStore}[typeParameters.params]`
+
+export const ngModuleDecorator = `ClassDeclaration > Decorator > CallExpression[callee.name='NgModule']`
+
+export const ngModuleProviders = `${ngModuleDecorator} ObjectExpression Property[key.name='providers'] > ArrayExpression Identifier`
+
+export const ngModuleImports = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='EffectsModule'][callee.property.name=/forRoot|forFeature/] ArrayExpression > Identifier`

--- a/tests/rules/no-effects-in-providers.test.ts
+++ b/tests/rules/no-effects-in-providers.test.ts
@@ -1,0 +1,95 @@
+import { stripIndent } from 'common-tags'
+import rule, {
+  ruleName,
+  messageId,
+} from '../../src/rules/no-effects-in-providers'
+import { ruleTester } from '../utils'
+
+ruleTester().run(ruleName, rule, {
+  valid: [
+    `
+    @NgModule({
+      imports: [
+        StoreModule.forFeature('persons', {"foo": "bar"}),
+        EffectsModule.forRoot([RootEffectOne]),
+        EffectsModule.forFeature([FeatEffectOne]),
+      ],
+      providers: [FeatEffectTwo, UnRegisteredEffect, FeatEffectThree, RootEffectTwo],
+    })
+    export class AppModule {}`,
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+      @NgModule({
+        imports: [
+          StoreModule.forFeature('persons', {"foo": "bar"}),
+          EffectsModule.forRoot([RootEffectOne, RootEffectTwo]),
+          EffectsModule.forFeature([FeatEffectOne, FeatEffectTwo]),
+          EffectsModule.forFeature([FeatEffectThree]),
+        ],
+        providers: [FeatEffectTwo, UnRegisteredEffect, FeatEffectThree, RootEffectTwo],
+      })
+      export class AppModule {}`,
+      errors: [
+        {
+          messageId,
+          line: 8,
+          column: 15,
+          endLine: 8,
+          endColumn: 28,
+        },
+        {
+          messageId,
+          line: 8,
+          column: 50,
+          endLine: 8,
+          endColumn: 65,
+        },
+        {
+          messageId,
+          line: 8,
+          column: 67,
+          endLine: 8,
+          endColumn: 80,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+      @NgModule({
+        providers: [FeatEffectTwo, UnRegisteredEffect, FeatEffectThree, RootEffectTwo],
+        imports: [
+          StoreModule.forFeature('persons', {"foo": "bar"}),
+          EffectsModule.forRoot([RootEffectOne, RootEffectTwo]),
+          EffectsModule.forFeature([FeatEffectOne, FeatEffectTwo]),
+          EffectsModule.forFeature([FeatEffectThree]),
+        ],
+      })
+      export class AppModule {}`,
+      errors: [
+        {
+          messageId,
+          line: 2,
+          column: 15,
+          endLine: 2,
+          endColumn: 28,
+        },
+        {
+          messageId,
+          line: 2,
+          column: 50,
+          endLine: 2,
+          endColumn: 65,
+        },
+        {
+          messageId,
+          line: 2,
+          column: 67,
+          endLine: 2,
+          endColumn: 80,
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
This a basic migration from ngrx-tslint-rules but this rule can only detect errors if effects are imported and provided in the same file. So it won't catch a lot of errors but it's better than nothing.

I needed to wait for decorator:exit so that errors would be reported for the providers even if providers are defined before the imports.
I added an error test case to validate this point