### PR TITLE
feat: adds on-reducer-explicit-return-type rule

### DIFF
--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -9,6 +9,7 @@
     "ngrx/no-dispatch-in-effects": "error",
     "ngrx/no-effect-decorator": "error",
     "ngrx/no-effects-in-providers": "error",
-    "ngrx/use-selector-in-select": "error"
+    "ngrx/use-selector-in-select": "error",
+    "ngrx/on-function-explicit-return-type": "error"
   }
 }

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -25,6 +25,9 @@ import noEffectsInProviders, {
 import useSelectorInSelect, {
   ruleName as useSelectorInSelectRuleName,
 } from './use-selector-in-select'
+import onFunctionExplicitReturnType, {
+  ruleName as onFunctionExplicitReturnTypeRuleName,
+} from './on-function-explicit-return-type'
 
 const ruleNames = {
   actionHygieneRuleName,
@@ -36,6 +39,7 @@ const ruleNames = {
   noEffectDecoratorRuleName,
   noEffectsInProvidersRuleName,
   useSelectorInSelectRuleName,
+  onFunctionExplicitReturnTypeRuleName,
 }
 
 export const rules = {
@@ -48,4 +52,5 @@ export const rules = {
   [ruleNames.noEffectDecoratorRuleName]: noEffectDecorator,
   [ruleNames.noEffectsInProvidersRuleName]: noEffectsInProviders,
   [ruleNames.useSelectorInSelectRuleName]: useSelectorInSelect,
+  [ruleNames.onFunctionExplicitReturnTypeRuleName]: onFunctionExplicitReturnType,
 }

--- a/src/rules/on-function-explicit-return-type.ts
+++ b/src/rules/on-function-explicit-return-type.ts
@@ -1,0 +1,41 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+
+import { onFunctionWithoutType } from './utils'
+
+export const ruleName = 'on-function-explicit-return-type'
+
+export const messageId = 'onFunctionExplicitReturnType'
+export type MessageIds = typeof messageId
+
+type Options = []
+
+export default ESLintUtils.RuleCreator(name => name)<Options, MessageIds>({
+  name: ruleName,
+  meta: {
+    type: 'problem',
+    docs: {
+      category: 'Possible Errors',
+      description: 'On function should have an explicit return type',
+      extraDescription: [
+        'This rule forces the on function to have an explicit return type when defined with an arrow function.',
+      ],
+      recommended: 'error',
+    },
+    schema: [],
+    messages: {
+      [messageId]:
+        'On functions should have an explicit return type when using arrow functions, on(action, (state):State => {}',
+    },
+  },
+  defaultOptions: [],
+  create: context => {
+    return {
+      [onFunctionWithoutType](node: TSESTree.TSTypeReference) {
+        context.report({
+          node,
+          messageId,
+        })
+      },
+    }
+  },
+})

--- a/src/rules/utils/selectors/index.ts
+++ b/src/rules/utils/selectors/index.ts
@@ -28,3 +28,5 @@ const pipeableSelect = `CallExpression[callee.property.name="pipe"] CallExpressi
 const storeSelect = `CallExpression[callee.object.name='store'][callee.property.name='select']`
 
 export const select = `${pipeableSelect} Literal, ${storeSelect} Literal, ${pipeableSelect} ArrowFunctionExpression, ${storeSelect} ArrowFunctionExpression`
+
+export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'] CallExpression[callee.name='on'] ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`

--- a/tests/rules/on-function-explicit-return-type.test.ts
+++ b/tests/rules/on-function-explicit-return-type.test.ts
@@ -1,0 +1,88 @@
+import { stripIndent } from 'common-tags'
+import rule, {
+  ruleName,
+  messageId,
+} from '../../src/rules/on-function-explicit-return-type'
+import { ruleTester } from '../utils'
+
+ruleTester().run(ruleName, rule, {
+  valid: [
+    `
+      const reducer = createReducer(
+        initialState,
+        on(
+          increment,
+          (s): State => ({
+            ...s,
+            counter: s.counter + 1,
+          }),
+        ),
+      )`,
+    `
+    const reducer = createReducer(
+      initialState,
+      on(increment, incrementFunc),
+      on(increment, s => incrementFunc(s)),
+      on(increment, (s): State => incrementFunc(s)),
+    )`,
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+        const reducer = createReducer(
+          initialState,
+          on(increment, s => ({
+            ...s,
+            counter: s.counter + 1,
+          })),
+        )`,
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 17,
+          endLine: 6,
+          endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        const reducer = createReducer(
+          initialState,
+          on(increase, (s, action) => ({
+            ...s,
+            counter: s.counter + action.value,
+          })),
+        )`,
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 16,
+          endLine: 6,
+          endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        const reducer = createReducer(
+          initialState,
+          on(increase, (s, { value }) => ({
+            ...s,
+            counter: s.counter + value,
+          })),
+        )`,
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 16,
+          endLine: 6,
+          endColumn: 5,
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
Here is the newly added rule.

I must say I am not a big fan of the rule name. "On reducer" makes me think we are talking about the reducer itself but that's not really the case.

I thought of something like "state-change-function-explicit-return-type" but it's a bit long and I don't know if everybody calls these functions "state change function". I found this name in NGRX documentation though.

"on-function-explicit-return-type" would be a bit clearer to me but we're still not typing the "on" function either.

As it was done on tslint repo, I didn't add the rule to the recommended config although I don't fully understand why we would not.