### PR TITLE
fix: do not report on-function-explicit-return-type error when using immer

### DIFF
--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -9,7 +9,7 @@
     "ngrx/no-dispatch-in-effects": "error",
     "ngrx/no-effect-decorator": "error",
     "ngrx/no-effects-in-providers": "error",
-    "ngrx/use-selector-in-select": "error",
-    "ngrx/on-function-explicit-return-type": "error"
+    "ngrx/on-function-explicit-return-type": "error",
+    "ngrx/use-selector-in-select": "error"
   }
 }

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -22,12 +22,12 @@ import noEffectDecorator, {
 import noEffectsInProviders, {
   ruleName as noEffectsInProvidersRuleName,
 } from './no-effects-in-providers'
-import useSelectorInSelect, {
-  ruleName as useSelectorInSelectRuleName,
-} from './use-selector-in-select'
 import onFunctionExplicitReturnType, {
   ruleName as onFunctionExplicitReturnTypeRuleName,
 } from './on-function-explicit-return-type'
+import useSelectorInSelect, {
+  ruleName as useSelectorInSelectRuleName,
+} from './use-selector-in-select'
 
 const ruleNames = {
   actionHygieneRuleName,
@@ -38,8 +38,8 @@ const ruleNames = {
   noDispatchInEffectsRuleName,
   noEffectDecoratorRuleName,
   noEffectsInProvidersRuleName,
-  useSelectorInSelectRuleName,
   onFunctionExplicitReturnTypeRuleName,
+  useSelectorInSelectRuleName,
 }
 
 export const rules = {

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -29,4 +29,4 @@ const storeSelect = `CallExpression[callee.object.name='store'][callee.property.
 
 export const select = `${pipeableSelect} Literal, ${storeSelect} Literal, ${pipeableSelect} ArrowFunctionExpression, ${storeSelect} ArrowFunctionExpression`
 
-export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'] CallExpression[callee.name='on'] ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`
+export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'] CallExpression[callee.name='on'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`

--- a/tests/rules/on-function-explicit-return-type.test.ts
+++ b/tests/rules/on-function-explicit-return-type.test.ts
@@ -25,6 +25,16 @@ ruleTester().run(ruleName, rule, {
       on(increment, s => incrementFunc(s)),
       on(increment, (s): State => incrementFunc(s)),
     )`,
+    `
+    const reducer = createReducer(
+      initialState,
+      on(
+        increment,
+        produce((draft: State, action) => {
+            draft.counter++;
+        }),
+      ),
+    )`,
   ],
   invalid: [
     {


### PR DESCRIPTION
The selector was not correct and reported an error when using immer produce function.