### PR TITLE
feat: adds no-multiple-actions-in-effects rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8955,6 +8955,12 @@
         "tslib": "^1.8.1"
       }
     },
+    "tsutils-etc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tsutils-etc/-/tsutils-etc-1.2.2.tgz",
+      "integrity": "sha512-5g2cXpD1OoVc/MLZxh5PuHXhlnYQmuRiW66e1n91j+2J/Pw5lfmVcZAghoDVBdltDXGaCjy8ZttXaX2u/MjHgg==",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.0.0",
+    "tsutils-etc": "^1.2.2",
     "typescript": "^3.9.3"
   }
 }

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -16,6 +16,9 @@ import noEffectDecoratorAndCreator, {
 import noEffectsInProviders, {
   ruleName as noEffectsInProvidersRuleName,
 } from './no-effects-in-providers'
+import noMultipleActionsInEffects, {
+  ruleName as noMultipleActionsInEffectsRuleName,
+} from './no-multiple-actions-in-effects'
 import noMultipleStores, {
   ruleName as noMultipleStoresRuleName,
 } from './no-multiple-stores'
@@ -37,9 +40,10 @@ const ruleNames = {
   actionHygieneRuleName,
   avoidDispatchingMultipleActionsSequentiallyRuleName,
   noDispatchInEffectsRuleName,
-  noEffectDecoratorRuleName,
   noEffectDecoratorAndCreatorRuleName,
+  noEffectDecoratorRuleName,
   noEffectsInProvidersRuleName,
+  noMultipleActionsInEffectsRuleName,
   noMultipleStoresRuleName,
   noReducerInKeyNamesRuleName,
   noTypedStoreRuleName,
@@ -55,6 +59,7 @@ export const rules = {
   [ruleNames.noEffectDecoratorAndCreatorRuleName]: noEffectDecoratorAndCreator,
   [ruleNames.noEffectDecoratorRuleName]: noEffectDecorator,
   [ruleNames.noEffectsInProvidersRuleName]: noEffectsInProviders,
+  [ruleNames.noMultipleActionsInEffectsRuleName]: noMultipleActionsInEffects,
   [ruleNames.noMultipleStoresRuleName]: noMultipleStores,
   [ruleNames.noReducerInKeyNamesRuleName]: noReducerInKeyNames,
   [ruleNames.noTypedStoreRuleName]: noTypedStore,

--- a/src/rules/no-multiple-actions-in-effects.ts
+++ b/src/rules/no-multiple-actions-in-effects.ts
@@ -1,0 +1,46 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+
+import { effectsArrowReturn, effectsReturn, docsUrl, typecheck } from '../utils'
+
+export const ruleName = 'no-multiple-actions-in-effects'
+
+export const messageId = 'noMultipleActionsInEffects'
+export type MessageIds = typeof messageId
+
+type Options = []
+
+export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
+  name: ruleName,
+  meta: {
+    type: 'problem',
+    docs: {
+      category: 'Possible Errors',
+      description: 'An Effect should not return multiple actions.',
+      recommended: 'error',
+    },
+    schema: [],
+    messages: {
+      [messageId]: 'An Effect should not return multiple actions.',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      [effectsArrowReturn](node: TSESTree.ArrayExpression) {
+        context.report({
+          node,
+          messageId,
+        })
+      },
+      [effectsReturn](node: TSESTree.ReturnStatement) {
+        const { couldBeOfType } = typecheck(context)
+        if (couldBeOfType(node.argument, 'Array')) {
+          context.report({
+            node: node.argument,
+            messageId,
+          })
+        }
+      },
+    }
+  },
+})

--- a/src/utils/helper-functions/index.ts
+++ b/src/utils/helper-functions/index.ts
@@ -1,4 +1,6 @@
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
+import { RuleContext } from '@typescript-eslint/experimental-utils/dist/ts-eslint/Rule'
+import { couldBeType } from 'tsutils-etc'
 
 export const docsUrl = (ruleName: string) =>
   `https://github.com/timdeschryver/eslint-plugin-ngrx/tree/master/docs/rules/${ruleName}.md`
@@ -9,4 +11,52 @@ export function isIdentifier(node: TSESTree.Node): node is TSESTree.Identifier {
 
 export function isLiteral(node: TSESTree.Node): node is TSESTree.Literal {
   return node.type === AST_NODE_TYPES.Literal
+}
+
+function getParserServices(
+  context: Readonly<RuleContext<string, readonly unknown[]>>,
+) {
+  if (
+    !context.parserServices ||
+    !context.parserServices.program ||
+    !context.parserServices.esTreeNodeToTSNodeMap
+  ) {
+    throw new Error(
+      'This rule requires you to use `@typescript-eslint/parser` and to specify a `project` in `parserOptions`.',
+    )
+  }
+  return context.parserServices
+}
+
+export function typecheck(
+  context: Readonly<RuleContext<string, readonly unknown[]>>,
+) {
+  const service = getParserServices(context)
+  const nodeMap = service.esTreeNodeToTSNodeMap
+  const typeChecker = service.program.getTypeChecker()
+
+  const getTSType = (node: TSESTree.Node) => {
+    const tsNode = nodeMap.get(node)
+    return typeChecker.getTypeAtLocation(tsNode)
+  }
+
+  const couldBeOfType = (
+    node: TSESTree.Node,
+    name: string | RegExp,
+    qualified?: { name: RegExp },
+  ) => {
+    const tsType = getTSType(node)
+    return couldBeType(
+      tsType,
+      name,
+      qualified ? { ...qualified, typeChecker } : undefined,
+    )
+  }
+
+  return {
+    nodeMap,
+    typeChecker,
+    getTSType,
+    couldBeOfType,
+  }
 }

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -4,8 +4,6 @@ export const effectDecorator = `ClassProperty > Decorator[expression.callee.name
 
 export const actionCreator = `CallExpression[callee.name=/createAction.*/]`
 
-export const reducerOn = `CallExpression[callee.name='createReducer'] > CallExpression[callee.name='on']`
-
 export const constructorExit = `MethodDefinition[kind='constructor']:exit`
 
 const actionDispatch =
@@ -34,3 +32,9 @@ export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'
 export const storeActionReducerMap = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='StoreModule'][callee.property.name=/forRoot|forFeature/] > ObjectExpression > Property`
 
 export const actionReducerMap = `VariableDeclarator[id.typeAnnotation.typeAnnotation.typeName.name='ActionReducerMap'] > ObjectExpression > Property`
+
+const effectsOperator = `ClassProperty > CallExpression[callee.name='createEffect'] CallExpression[callee.name=/switchMap|concatMap|mergeMap|flatMap|exhaustMap/]`
+
+export const effectsArrowReturn = `${effectsOperator} > ArrowFunctionExpression > ArrayExpression`
+
+export const effectsReturn = `${effectsOperator} ReturnStatement`

--- a/tests/rules/no-multiple-actions-in-effects.test.ts
+++ b/tests/rules/no-multiple-actions-in-effects.test.ts
@@ -1,0 +1,170 @@
+import { stripIndent } from 'common-tags'
+import rule, {
+  ruleName,
+  messageId,
+} from '../../src/rules/no-multiple-actions-in-effects'
+import { ruleTester } from '../utils'
+
+ruleTester().run(ruleName, rule, {
+  valid: [
+    {
+      code: `
+    export class Effects {
+      seven$ = createEffect(() =>
+        this.actions$.pipe(map(() => foo()))
+      )
+    }`,
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      filename: 'fake.ts',
+    },
+    {
+      code: `
+    export class Effects {
+      five$ = createEffect(() =>
+        this.actions$.pipe(switchMap(() => {
+          return of(foo())
+        }))
+      )
+    }`,
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      filename: 'fake.ts',
+    },
+    {
+      code: `
+    export class Effects {
+      six$ = createEffect(() =>
+        this.actions$.pipe(
+          exhaustMap(() => {
+            return of({}).pipe(
+              map(response => foo()),
+              catchError(() => of(bar()))
+            );
+          })
+        )
+      )
+    }`,
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      filename: 'fake.ts',
+    },
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+export class Effects {
+  one$ = createEffect(() =>
+    this.actions$.pipe(switchMap(_ => [foo(), bar()])),
+  )
+}`,
+      filename: 'fake.ts',
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 39,
+          endLine: 3,
+          endColumn: 53,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+export class Effects {
+  two$ = createEffect(() =>
+    this.actions$.pipe(mergeMap(_ => { return [foo(), bar()] }))
+  )
+}`,
+      filename: 'fake.ts',
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 47,
+          endLine: 3,
+          endColumn: 61,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+export class Effects {
+  three$ = createEffect(() =>
+    this.actions$.pipe(exhaustMap(function() { return [foo(), bar()] }))
+  )
+}`,
+      filename: 'fake.ts',
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 55,
+          endLine: 3,
+          endColumn: 69,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+export class Effects {
+  eight$ = createEffect(() =>
+    this.actions$.pipe(
+      exhaustMap(() => {
+        return of({}).pipe(
+          switchMap(() => [foo(), bar()]),
+          catchError(() => of(bar()))
+        );
+      })
+    )
+  )
+}`,
+      filename: 'fake.ts',
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      errors: [
+        {
+          messageId,
+          line: 6,
+          column: 27,
+          endLine: 6,
+          endColumn: 41,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+export class Effects {
+  four$ = createEffect(() =>
+    this.actions$.pipe(concatMap(() => { let actions: Action[] = []; return actions; }))
+  )
+}`,
+      filename: 'fake.ts',
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+      errors: [
+        {
+          messageId,
+          line: 3,
+          column: 77,
+          endLine: 3,
+          endColumn: 84,
+        },
+      ],
+    },
+  ],
+})

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -2,13 +2,11 @@ import { resolve } from 'path'
 import { RuleTester } from '@typescript-eslint/experimental-utils/dist/ts-eslint'
 
 export function ruleTester() {
-  const ruleTester = new RuleTester({
+  return new RuleTester({
     parser: resolve('./node_modules/@typescript-eslint/parser'),
     parserOptions: {
       ecmaVersion: 6,
       sourceType: 'module',
     },
   })
-
-  return ruleTester
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts"],
+  "files": ["fake.ts"]
 }


### PR DESCRIPTION
This rule's implementation gave me headaches... Working with types in ESLint is not that easy after all.

I didn't manage to check if the return is of type `Action[]` so I've only been looking for returned arrays in effects.
It covers all test cases that I found in ngrx-tslint-rules but I am not sure it will not report false positives.

What do you think?