### PR TITLE
feat: add select-style rule

### DIFF
--- a/docs/rules/select-style.md
+++ b/docs/rules/select-style.md
@@ -1,0 +1,1 @@
+# select-style

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -28,6 +28,7 @@ import noTypedStore, {
 import onFunctionExplicitReturnType, {
   ruleName as onFunctionExplicitReturnTypeRuleName,
 } from './on-function-explicit-return-type'
+import selectStyle, { ruleName as selectStyleRuleName } from './select-style'
 import useSelectorInSelect, {
   ruleName as useSelectorInSelectRuleName,
 } from './use-selector-in-select'
@@ -43,6 +44,7 @@ const ruleNames = {
   noReducerInKeyNamesRuleName,
   noTypedStoreRuleName,
   onFunctionExplicitReturnTypeRuleName,
+  selectStyleRuleName,
   useSelectorInSelectRuleName,
 }
 
@@ -57,5 +59,6 @@ export const rules = {
   [ruleNames.noReducerInKeyNamesRuleName]: noReducerInKeyNames,
   [ruleNames.noTypedStoreRuleName]: noTypedStore,
   [ruleNames.onFunctionExplicitReturnTypeRuleName]: onFunctionExplicitReturnType,
+  [ruleNames.selectStyleRuleName]: selectStyle,
   [ruleNames.useSelectorInSelectRuleName]: useSelectorInSelect,
 }

--- a/src/rules/select-style.ts
+++ b/src/rules/select-style.ts
@@ -1,0 +1,67 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+
+import { docsUrl, pipeableSelect, storeSelect } from '../utils'
+
+export const ruleName = 'select-style'
+
+export const methodSelectMessageId = 'storeSelect'
+export const operatorSelectMessageId = 'operatorSelect'
+
+export type MessageIds =
+  | typeof methodSelectMessageId
+  | typeof operatorSelectMessageId
+
+export const OPERATOR = 'operator'
+export const METHOD = 'method'
+
+type Options = [{ mode: string }]
+
+export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
+  name: ruleName,
+  meta: {
+    type: 'problem',
+    docs: {
+      category: 'Possible Errors',
+      description: `Selectors can be used either with 'select' as a pipeable operator or as a method`,
+      recommended: false,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          mode: {
+            enum: [OPERATOR, METHOD],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      [methodSelectMessageId]:
+        'Selectors should be used with select method: this.store.select(selector)',
+      [operatorSelectMessageId]:
+        'Selectors should be used with the pipeable operator: this.store.pipe(select(selector))',
+    },
+  },
+  defaultOptions: [{ mode: OPERATOR }],
+  create: (context, [{ mode }]) => {
+    return {
+      [pipeableSelect](node: TSESTree.CallExpression) {
+        if (mode === METHOD) {
+          context.report({
+            node,
+            messageId: methodSelectMessageId,
+          })
+        }
+      },
+      [storeSelect](node: TSESTree.Identifier) {
+        if (mode === OPERATOR) {
+          context.report({
+            node,
+            messageId: operatorSelectMessageId,
+          })
+        }
+      },
+    }
+  },
+})

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -24,8 +24,8 @@ export const ngModuleProviders = `${ngModuleDecorator} ObjectExpression Property
 
 export const ngModuleImports = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='EffectsModule'][callee.property.name=/forRoot|forFeature/] ArrayExpression > Identifier`
 
-const pipeableSelect = `CallExpression[callee.property.name="pipe"] CallExpression[callee.name="select"]`
-const storeSelect = `CallExpression[callee.object.name='store'][callee.property.name='select']`
+export const pipeableSelect = `CallExpression[callee.property.name="pipe"] CallExpression[callee.name="select"]`
+export const storeSelect = `CallExpression[callee.object.property.name='store'][callee.property.name='select']`
 
 export const select = `${pipeableSelect} Literal, ${storeSelect} Literal, ${pipeableSelect} ArrowFunctionExpression, ${storeSelect} ArrowFunctionExpression`
 

--- a/tests/rules/store-select.test.ts
+++ b/tests/rules/store-select.test.ts
@@ -1,0 +1,66 @@
+import { stripIndent } from 'common-tags'
+import rule, {
+  METHOD,
+  OPERATOR,
+  operatorSelectMessageId,
+  ruleName,
+  methodSelectMessageId,
+} from '../../src/rules/select-style'
+import { ruleTester } from '../utils'
+
+ruleTester().run(ruleName, rule, {
+  valid: [
+    `this.store.pipe(select(selector));`,
+    {
+      code: `this.store.pipe(select(selector));`,
+      options: [{ mode: OPERATOR }],
+    },
+    {
+      code: `this.store.select(selector);`,
+      options: [{ mode: METHOD }],
+    },
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+        this.store.select(selector);`,
+      errors: [
+        {
+          messageId: operatorSelectMessageId,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        this.store.pipe(select(selector));`,
+      options: [{ mode: METHOD }],
+      errors: [
+        {
+          messageId: methodSelectMessageId,
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 33,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        this.store.select(selector);`,
+      options: [{ mode: OPERATOR }],
+      errors: [
+        {
+          messageId: operatorSelectMessageId,
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28,
+        },
+      ],
+    },
+  ],
+})

--- a/tests/rules/use-selector-in-select.test.ts
+++ b/tests/rules/use-selector-in-select.test.ts
@@ -7,15 +7,28 @@ import { ruleTester } from '../utils'
 
 ruleTester().run(ruleName, rule, {
   valid: [
-    `store.pipe(select(selectCustomers))`,
-    `store.pipe(select(selectorsObj.selectCustomers))`,
-    `store.select(selectCustomers)`,
-    `store.select(selectorsObj.selectCustomers)`,
+    `this.store.pipe(select(selectCustomers))`,
+    `this.store.pipe(select(selectorsObj.selectCustomers))`,
+    `this.store.select(selectCustomers)`,
+    `this.store.select(selectorsObj.selectCustomers)`,
   ],
   invalid: [
     {
       code: stripIndent`
-        store.pipe(select('customers'))`,
+        this.store.pipe(select('customers'))`,
+      errors: [
+        {
+          messageId,
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 35,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        this.store.select('customers')`,
       errors: [
         {
           messageId,
@@ -28,20 +41,27 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-        store.select('customers')`,
+        this.store.pipe(select('customers', 'orders'))`,
       errors: [
         {
           messageId,
           line: 1,
-          column: 14,
+          column: 24,
           endLine: 1,
-          endColumn: 25,
+          endColumn: 35,
+        },
+        {
+          messageId,
+          line: 1,
+          column: 37,
+          endLine: 1,
+          endColumn: 45,
         },
       ],
     },
     {
       code: stripIndent`
-        store.pipe(select('customers', 'orders'))`,
+        this.store.select('customers', 'orders')`,
       errors: [
         {
           messageId,
@@ -61,27 +81,20 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-        store.select('customers', 'orders')`,
+        this.store.pipe(select(state => state.customers))`,
       errors: [
         {
           messageId,
           line: 1,
-          column: 14,
+          column: 24,
           endLine: 1,
-          endColumn: 25,
-        },
-        {
-          messageId,
-          line: 1,
-          column: 27,
-          endLine: 1,
-          endColumn: 35,
+          endColumn: 48,
         },
       ],
     },
     {
       code: stripIndent`
-        store.pipe(select(state => state.customers))`,
+        this.store.select(state => state.customers)`,
       errors: [
         {
           messageId,
@@ -94,20 +107,20 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-        store.select(state => state.customers)`,
+        this.store.pipe(select(state => state.customers.orders))`,
       errors: [
         {
           messageId,
           line: 1,
-          column: 14,
+          column: 24,
           endLine: 1,
-          endColumn: 38,
+          endColumn: 55,
         },
       ],
     },
     {
       code: stripIndent`
-        store.pipe(select(state => state.customers.orders))`,
+        this.store.select(state => state.customers.orders)`,
       errors: [
         {
           messageId,
@@ -115,19 +128,6 @@ ruleTester().run(ruleName, rule, {
           column: 19,
           endLine: 1,
           endColumn: 50,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
-        store.select(state => state.customers.orders)`,
-      errors: [
-        {
-          messageId,
-          line: 1,
-          column: 14,
-          endLine: 1,
-          endColumn: 45,
         },
       ],
     },


### PR DESCRIPTION
Add a rule to define how selectors should be used in the project.

This rule is not part of recommended configuration.

The default value is 'operator' because it seems to be the recommended way in NGRX documentation and it allows to use more advanced features: 
- [Make use of rxjs operators](https://ngrx.io/guide/store/selectors#select-a-non-empty-state-using-pipeable-operators)
- [Extracting a pipeable operator](https://ngrx.io/guide/store/selectors#solution-extracting-a-pipeable-operator)

For ease (and because I use the underlying modifications), I'm including in this branch the commit for #27. So the bug fix should probably be merged before this one