### PR TITLE
fix(use-selector-in-select): allow parameters

### DIFF
--- a/src/rules/avoid-dispatching-multiple-actions-sequentially.ts
+++ b/src/rules/avoid-dispatching-multiple-actions-sequentially.ts
@@ -5,6 +5,7 @@ import {
   isCallExpression,
   isMemberExpression,
   isIdentifier,
+  injectedStore,
 } from '../utils'
 
 export const ruleName = 'avoid-dispatching-multiple-actions-sequentially'
@@ -33,9 +34,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   create: (context) => {
     let storeName = ''
     return {
-      [`MethodDefinition[kind='constructor'] Identifier[typeAnnotation.typeAnnotation.typeName.name="Store"]`](
-        node: TSESTree.Identifier,
-      ) {
+      [injectedStore](node: TSESTree.Identifier) {
         storeName = node.name
       },
       [`ClassDeclaration > ClassBody > MethodDefinition > FunctionExpression > BlockStatement`](

--- a/src/rules/no-multiple-stores.ts
+++ b/src/rules/no-multiple-stores.ts
@@ -28,8 +28,8 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     const injectedStores: TSESTree.Identifier[] = []
 
     return {
-      [injectedStore](node: TSESTree.TSTypeReference) {
-        injectedStores.push(node.parent.parent as TSESTree.Identifier)
+      [injectedStore](node: TSESTree.Identifier) {
+        injectedStores.push(node)
       },
       [constructorExit]() {
         if (injectedStores.length > 1) {

--- a/src/rules/no-multiple-stores.ts
+++ b/src/rules/no-multiple-stores.ts
@@ -32,14 +32,14 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
         injectedStores.push(node.parent.parent as TSESTree.Identifier)
       },
       [constructorExit]() {
-        injectedStores
-          .filter((_, i) => i > 0)
-          .forEach((node) => {
+        if (injectedStores.length > 1) {
+          injectedStores.forEach((node) => {
             context.report({
               node,
               messageId,
             })
           })
+        }
       },
     }
   },

--- a/src/utils/helper-functions/guards.ts
+++ b/src/utils/helper-functions/guards.ts
@@ -19,3 +19,9 @@ export function isMemberExpression(
 ): node is TSESTree.MemberExpression {
   return node.type === AST_NODE_TYPES.MemberExpression
 }
+
+export function isArrowFunctionExpression(
+  node: TSESTree.Node,
+): node is TSESTree.ArrowFunctionExpression {
+  return node.type === AST_NODE_TYPES.ArrowFunctionExpression
+}

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -8,9 +8,8 @@ export const constructorExit = `MethodDefinition[kind='constructor']:exit`
 
 export const dispatchInEffects = `ClassProperty > CallExpression:has(Identifier[name="createEffect"]) CallExpression > MemberExpression:has(Identifier[name="dispatch"]):has(MemberExpression > Identifier[name="store"])`
 
-export const injectedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name="Store"]`
-
-export const typedStore = `${injectedStore}[typeParameters.params]`
+export const injectedStore = `MethodDefinition[kind='constructor'] Identifier[typeAnnotation.typeAnnotation.typeName.name="Store"]`
+export const typedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name="Store"][typeParameters.params]`
 
 export const ngModuleDecorator = `ClassDeclaration > Decorator > CallExpression[callee.name='NgModule']`
 

--- a/tests/rules/no-multiple-stores.test.ts
+++ b/tests/rules/no-multiple-stores.test.ts
@@ -26,32 +26,36 @@ ruleTester().run(ruleName, rule, {
   invalid: [
     fromFixture(
       stripIndent`
-      export class NotOkNoVisibility {
-        constructor(store: Store, store2: Store){}
-                                  ~~~~~~~~~~~~~ [${messageId}]
-      }`,
+        export class NotOkNoVisibility {
+          constructor(store: Store, store2: Store){}
+                      ~~~~~~~~~~~~                  [${messageId}]
+                                    ~~~~~~~~~~~~~   [${messageId}]
+        }`,
     ),
     fromFixture(
       stripIndent`
-      export class NotOkOneVisibility {
-        constructor(store: Store, private store2: Store){}
-                                          ~~~~~~~~~~~~~ [${messageId}]
-      }`,
+        export class NotOkOneVisibility {
+          constructor(store: Store, private store2: Store){}
+                      ~~~~~~~~~~~~                        [${messageId}]
+                                            ~~~~~~~~~~~~~ [${messageId}]
+        }`,
     ),
     fromFixture(
       stripIndent`
-      export class NotOkBothVisibility {
-        constructor(private readonly store: Store, private store2: Store){}
-                                                           ~~~~~~~~~~~~~ [${messageId}]
-      }`,
+        export class NotOkBothVisibility {
+          constructor(private readonly store: Store, private store2: Store){}
+                                       ~~~~~~~~~~~~                          [${messageId}]
+                                                             ~~~~~~~~~~~~~   [${messageId}]
+        }`,
     ),
     fromFixture(
       stripIndent`
-      export class NotOkMultipleErrors {
-        constructor(private readonly store: Store, private store2: Store, private store3: Store){}
-                                                           ~~~~~~~~~~~~~                        [${messageId}]
-                                                                                  ~~~~~~~~~~~~~ [${messageId}]
-      }`,
+        export class NotOkMultipleErrors {
+          constructor(private readonly store: Store, private store2: Store, private store3: Store){}
+                                       ~~~~~~~~~~~~                                                [${messageId}]
+                                                             ~~~~~~~~~~~~~                         [${messageId}]
+                                                                                    ~~~~~~~~~~~~~  [${messageId}]
+        }`,
     ),
   ],
 })

--- a/tests/rules/use-selector-in-select.test.ts
+++ b/tests/rules/use-selector-in-select.test.ts
@@ -7,127 +7,173 @@ import { ruleTester } from '../utils'
 
 ruleTester().run(ruleName, rule, {
   valid: [
-    `this.store.pipe(select(selectCustomers))`,
-    `this.store.pipe(select(selectorsObj.selectCustomers))`,
-    `this.store.select(selectCustomers)`,
-    `this.store.select(selectorsObj.selectCustomers)`,
+    stripIndent`
+      export class Component {
+        view$ = this.store.pipe(select(selectCustomers))
+        constructor(store: Store){}
+      }`,
+    stripIndent`
+      export class Component {
+        view$ = this.store.select(selectCustomers)
+        constructor(store: Store){}
+      }`,
+    stripIndent`
+      export class Component {
+        view$ = this.store.pipe(select(selectorsObj.selectCustomers))
+        constructor(store: Store){}
+      }`,
+    stripIndent`
+      export class Component {
+        view$ = this.store.select(selectorsObj.selectCustomers)
+        constructor(store: Store){}
+      }`,
+    // https://github.com/timdeschryver/eslint-plugin-ngrx/issues/41
+    stripIndent`
+      export class Component {
+        view$ = this.store.pipe(select(selectQueryParam('parameter')))
+        constructor(store: Store){}
+      }`,
   ],
   invalid: [
     {
       code: stripIndent`
-        this.store.pipe(select('customers'))`,
+        export class Component {
+          view$ = this.store.pipe(select('customers'))
+          constructor(store: Store){}
+        }`,
       errors: [
         {
           messageId,
-          line: 1,
-          column: 24,
-          endLine: 1,
-          endColumn: 35,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
-        this.store.select('customers')`,
-      errors: [
-        {
-          messageId,
-          line: 1,
-          column: 19,
-          endLine: 1,
-          endColumn: 30,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
-        this.store.pipe(select('customers', 'orders'))`,
-      errors: [
-        {
-          messageId,
-          line: 1,
-          column: 24,
-          endLine: 1,
-          endColumn: 35,
-        },
-        {
-          messageId,
-          line: 1,
-          column: 37,
-          endLine: 1,
+          line: 2,
+          column: 34,
+          endLine: 2,
           endColumn: 45,
         },
       ],
     },
     {
       code: stripIndent`
-        this.store.select('customers', 'orders')`,
+        export class Component {
+          view$ = this.store.select('customers')
+          constructor(store: Store){}
+        }`,
       errors: [
         {
           messageId,
-          line: 1,
-          column: 19,
-          endLine: 1,
-          endColumn: 30,
-        },
-        {
-          messageId,
-          line: 1,
-          column: 32,
-          endLine: 1,
+          line: 2,
+          column: 29,
+          endLine: 2,
           endColumn: 40,
         },
       ],
     },
     {
       code: stripIndent`
-        this.store.pipe(select(state => state.customers))`,
+        export class Component {
+          view$ = this.store.pipe(select('customers', 'orders'))
+          constructor(store: Store){}
+        }`,
       errors: [
         {
           messageId,
-          line: 1,
-          column: 24,
-          endLine: 1,
-          endColumn: 48,
+          line: 2,
+          column: 34,
+          endLine: 2,
+          endColumn: 45,
         },
-      ],
-    },
-    {
-      code: stripIndent`
-        this.store.select(state => state.customers)`,
-      errors: [
         {
           messageId,
-          line: 1,
-          column: 19,
-          endLine: 1,
-          endColumn: 43,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
-        this.store.pipe(select(state => state.customers.orders))`,
-      errors: [
-        {
-          messageId,
-          line: 1,
-          column: 24,
-          endLine: 1,
+          line: 2,
+          column: 47,
+          endLine: 2,
           endColumn: 55,
         },
       ],
     },
     {
       code: stripIndent`
-        this.store.select(state => state.customers.orders)`,
+        export class Component {
+          view$ = this.store.select('customers', 'orders')
+          constructor(store: Store){}
+        }`,
       errors: [
         {
           messageId,
-          line: 1,
-          column: 19,
-          endLine: 1,
+          line: 2,
+          column: 29,
+          endLine: 2,
+          endColumn: 40,
+        },
+        {
+          messageId,
+          line: 2,
+          column: 42,
+          endLine: 2,
           endColumn: 50,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        export class Component {
+          view$ = this.store.pipe(select(s => s.customers))
+          constructor(store: Store){}
+        }`,
+      errors: [
+        {
+          messageId,
+          line: 2,
+          column: 34,
+          endLine: 2,
+          endColumn: 50,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        export class Component {
+          view$ = this.store.select(s => s.customers)
+          constructor(store: Store){}
+        }`,
+      errors: [
+        {
+          messageId,
+          line: 2,
+          column: 29,
+          endLine: 2,
+          endColumn: 45,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        export class Component {
+          view$ = this.store$.select(s => s.customers)
+          constructor(store$: Store){}
+        }`,
+      errors: [
+        {
+          messageId,
+          line: 2,
+          column: 30,
+          endLine: 2,
+          endColumn: 46,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        export class Component {
+          view$ = this.store$.pipe(select('customers'))
+          constructor(store$: Store){}
+        }`,
+      errors: [
+        {
+          messageId,
+          line: 2,
+          column: 35,
+          endLine: 2,
+          endColumn: 46,
         },
       ],
     },

--- a/tests/rules/use-selector-in-select.test.ts
+++ b/tests/rules/use-selector-in-select.test.ts
@@ -1,4 +1,5 @@
 import { stripIndent } from 'common-tags'
+import { fromFixture } from 'eslint-etc'
 import rule, {
   ruleName,
   messageId,
@@ -35,147 +36,71 @@ ruleTester().run(ruleName, rule, {
       }`,
   ],
   invalid: [
-    {
-      code: stripIndent`
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store.pipe(select('customers'))
-          constructor(store: Store){}
+                                         ~~~~~~~~~~~  [${messageId}]
+        constructor(store: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 34,
-          endLine: 2,
-          endColumn: 45,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
+    ),
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store.select('customers')
+                                    ~~~~~~~~~~~  [${messageId}]
           constructor(store: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 29,
-          endLine: 2,
-          endColumn: 40,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
+    ),
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store.pipe(select('customers', 'orders'))
+                                         ~~~~~~~~~~~            [${messageId}]
+                                                      ~~~~~~~~  [${messageId}]
           constructor(store: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 34,
-          endLine: 2,
-          endColumn: 45,
-        },
-        {
-          messageId,
-          line: 2,
-          column: 47,
-          endLine: 2,
-          endColumn: 55,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
+    ),
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store.select('customers', 'orders')
+                                    ~~~~~~~~~~~               [${messageId}]
+                                                 ~~~~~~~~     [${messageId}]
           constructor(store: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 29,
-          endLine: 2,
-          endColumn: 40,
-        },
-        {
-          messageId,
-          line: 2,
-          column: 42,
-          endLine: 2,
-          endColumn: 50,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
+    ),
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store.pipe(select(s => s.customers))
+                                         ~~~~~~~~~~~~~~~~  [${messageId}]
           constructor(store: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 34,
-          endLine: 2,
-          endColumn: 50,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
+    ),
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store.select(s => s.customers)
+                                    ~~~~~~~~~~~~~~~~  [${messageId}]
           constructor(store: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 29,
-          endLine: 2,
-          endColumn: 45,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
+    ),
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store$.select(s => s.customers)
+                                     ~~~~~~~~~~~~~~~~  [${messageId}]
           constructor(store$: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 30,
-          endLine: 2,
-          endColumn: 46,
-        },
-      ],
-    },
-    {
-      code: stripIndent`
+    ),
+    fromFixture(
+      stripIndent`
         export class Component {
           view$ = this.store$.pipe(select('customers'))
+                                          ~~~~~~~~~~~  [${messageId}]
           constructor(store$: Store){}
         }`,
-      errors: [
-        {
-          messageId,
-          line: 2,
-          column: 35,
-          endLine: 2,
-          endColumn: 46,
-        },
-      ],
-    },
+    ),
   ],
 })


### PR DESCRIPTION
Closes #41

@jsaguet this is basically a re-write of the rule.
The rule also takes into account when the store is renamed to for example `store$` 