### PR TITLE
fix: level of rxjs/no-cyclic-action

### DIFF
--- a/scripts/generate-config.ts
+++ b/scripts/generate-config.ts
@@ -19,7 +19,7 @@ const recommendedRules = Object.entries(rules).reduce(
 )
 
 const rxjsRules = {
-  'rxjs/no-cyclic-action': 'warning',
+  'rxjs/no-cyclic-action': 'warn',
   'rxjs/no-unsafe-catch': 'error',
   'rxjs/no-unsafe-first': 'error',
   'rxjs/no-unsafe-switchmap': 'error',

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -13,7 +13,7 @@ export = {
     'ngrx/no-typed-store': 'error',
     'ngrx/on-function-explicit-return-type': 'error',
     'ngrx/use-selector-in-select': 'error',
-    'rxjs/no-cyclic-action': 'warning',
+    'rxjs/no-cyclic-action': 'warn',
     'rxjs/no-unsafe-catch': 'error',
     'rxjs/no-unsafe-first': 'error',
     'rxjs/no-unsafe-switchmap': 'error',


### PR DESCRIPTION
The recent addition of the rxjs/no-cycle-action rule broke the recommended config.

Error message: Configuration for rule "rxjs/no-cyclic-action" is invalid:  Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"warning"').

This PR changes the level for this rule to a valid eslint value.