### PR TITLE
fix: update eslint-plugin-rxjs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2510,7 +2510,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3225,7 +3224,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-etc/-/eslint-etc-4.0.0.tgz",
       "integrity": "sha512-M6R0dUAT/pC+dZRP9uMOkAnuCssMtUuwtgwgIZfk933wr+uP0bjog61WHHXM2ghNF0hIqOokPb5/lJlXLD+NCg==",
-      "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.0",
         "tsutils": "^3.17.1",
@@ -3242,9 +3240,9 @@
       }
     },
     "eslint-plugin-rxjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-rxjs/-/eslint-plugin-rxjs-2.1.3.tgz",
-      "integrity": "sha512-suPh/0rmZZgYl2tvHat6HcnTAwApamXeR6rI9sXCCs/vjeXqK/tBBZfgjgMHTP+JB78R6df2fJpW3UQRmzUcNQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-rxjs/-/eslint-plugin-rxjs-2.1.4.tgz",
+      "integrity": "sha512-XD80UD91ObvY0K8iLz13IT3h0w9P6ZdMxl5zTUuYNF9k61QxQJehut4bF7pWBEhmI0RMETXU8b2ytPajOLrDkQ==",
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.0",
         "common-tags": "^1.8.0",
@@ -3261,16 +3259,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
           "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
-        },
-        "eslint-etc": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-etc/-/eslint-etc-4.0.0.tgz",
-          "integrity": "sha512-M6R0dUAT/pC+dZRP9uMOkAnuCssMtUuwtgwgIZfk933wr+uP0bjog61WHHXM2ghNF0hIqOokPb5/lJlXLD+NCg==",
-          "requires": {
-            "@typescript-eslint/experimental-utils": "^4.0.0",
-            "tsutils": "^3.17.1",
-            "tsutils-etc": "^1.2.2"
-          }
         },
         "tslib": {
           "version": "2.0.3",
@@ -6554,17 +6542,6 @@
         "chalk": "~4.1.0",
         "glob": "~7.1.6",
         "prompts": "~2.3.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@angular-devkit/schematics": "^11.0.1",
     "@typescript-eslint/experimental-utils": "^4.7.0",
-    "eslint-plugin-rxjs": "2.1.3",
+    "eslint-plugin-rxjs": "^2.1.4",
     "tsutils-etc": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
version update to solve https://github.com/cartant/eslint-plugin-rxjs/issues/54 issue.

I was wondering if peer dependency wouldn't be better to let the user select the version to use.
What do you think ?