### PR TITLE
fix: no-multiple-actions-in-effects not reporting mapTo operators

### DIFF
--- a/src/rules/no-multiple-actions-in-effects.ts
+++ b/src/rules/no-multiple-actions-in-effects.ts
@@ -1,6 +1,11 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { effectsArrowReturn, effectsReturn, docsUrl, typecheck } from '../utils'
+import {
+  effectsImplicitReturn,
+  effectsReturn,
+  docsUrl,
+  typecheck,
+} from '../utils'
 
 export const ruleName = 'no-multiple-actions-in-effects'
 
@@ -26,17 +31,17 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      [effectsArrowReturn](node: TSESTree.ArrayExpression) {
+      [effectsImplicitReturn](node: TSESTree.ArrayExpression) {
         context.report({
           node,
           messageId,
         })
       },
-      [effectsReturn](node: TSESTree.ReturnStatement) {
+      [effectsReturn]({ argument }: TSESTree.ReturnStatement) {
         const { couldBeOfType } = typecheck(context)
-        if (couldBeOfType(node.argument, 'Array')) {
+        if (couldBeOfType(argument, 'Array')) {
           context.report({
-            node: node.argument,
+            node: argument,
             messageId,
           })
         }

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -28,8 +28,13 @@ export const storeActionReducerMap = `${ngModuleDecorator} ObjectExpression Prop
 
 export const actionReducerMap = `VariableDeclarator[id.typeAnnotation.typeAnnotation.typeName.name='ActionReducerMap'] > ObjectExpression > Property`
 
-const effectsOperator = `ClassProperty > CallExpression[callee.name='createEffect'] CallExpression[callee.name=/switchMap|concatMap|mergeMap|flatMap|exhaustMap/]`
+const createEffectExpression = `ClassProperty > CallExpression[callee.name='createEffect']`
 
-export const effectsArrowReturn = `${effectsOperator} > ArrowFunctionExpression > ArrayExpression`
+const mapOperators = '(concat|exhaust|flat|merge|switch)Map'
+const mapToOperators = '(concat|merge|switch)MapTo'
+const mapOperatorsExpression = `${createEffectExpression} CallExpression[callee.name=/^${mapOperators}$/]`
+const mapToOperatorsExpression = `${createEffectExpression} CallExpression[callee.name=/^${mapToOperators}$/]`
 
-export const effectsReturn = `${effectsOperator} ReturnStatement`
+export const effectsImplicitReturn = `${mapOperatorsExpression} > ArrowFunctionExpression > ArrayExpression, ${mapToOperatorsExpression} ArrayExpression`
+
+export const effectsReturn = `${mapOperatorsExpression} ReturnStatement`

--- a/tests/rules/no-multiple-actions-in-effects.test.ts
+++ b/tests/rules/no-multiple-actions-in-effects.test.ts
@@ -37,6 +37,54 @@ ruleTester().run(ruleName, rule, {
     {
       code: `
         export class Effects {
+          thirteen$ = createEffect(() =>
+            this.actions$.pipe(mapTo(foo()))
+          )
+        }`,
+      parserOptions: {
+        project: './tsconfig.tests.eslint.json',
+      },
+      filename: 'test.ts',
+    },
+    {
+      code: `
+        export class Effects {
+          eleven$ = createEffect(() =>
+            this.actions$.pipe(switchMapTop([foo()]))
+          )
+        }`,
+      parserOptions: {
+        project: './tsconfig.tests.eslint.json',
+      },
+      filename: 'test.ts',
+    },
+    {
+      code: `
+        export class Effects {
+          twelve$ = createEffect(() =>
+            this.actions$.pipe(aconcatMapTo([bar()]))
+          )
+        }`,
+      parserOptions: {
+        project: './tsconfig.tests.eslint.json',
+      },
+      filename: 'test.ts',
+    },
+    {
+      code: `
+        export class Effects {
+          nine$ = createEffect(() =>
+            this.actions$.pipe(mergeMapTo(foo()))
+          )
+        }`,
+      parserOptions: {
+        project: './tsconfig.tests.eslint.json',
+      },
+      filename: 'test.ts',
+    },
+    {
+      code: `
+        export class Effects {
           six$ = createEffect(() =>
             this.actions$.pipe(
               exhaustMap(() => {
@@ -59,8 +107,8 @@ ruleTester().run(ruleName, rule, {
       stripIndent`
         export class Effects {
           one$ = createEffect(() =>
-            this.actions$.pipe(switchMap(_ => [foo(), bar()])),
-                                              ~~~~~~~~~~~~~~  [${messageId}]
+            this.actions$.pipe(flatMap(_ => [foo(), bar()])),
+                                            ~~~~~~~~~~~~~~  [${messageId}]
           )
       }`,
       {
@@ -91,7 +139,22 @@ ruleTester().run(ruleName, rule, {
           three$ = createEffect(() =>
             this.actions$.pipe(exhaustMap(function() { return [foo(), bar()] }))
                                                               ~~~~~~~~~~~~~~  [${messageId}]
-            )
+          )
+        }`,
+      {
+        parserOptions: {
+          project: './tsconfig.tests.eslint.json',
+        },
+        filename: 'test.ts',
+      },
+    ),
+    fromFixture(
+      stripIndent`
+        export class Effects {
+          readonly ten$ = createEffect(() =>
+            this.actions$.pipe(concatMapTo([test(), baz()]))
+                                           ~~~~~~~~~~~~~~~  [${messageId}]
+          )
         }`,
       {
         parserOptions: {


### PR DESCRIPTION
Fixes #61.

in addition to fix the error reported in #61, I also changed the selectors to search for the exact names, instead of part of them, to avoid a possible problem with custom operators and also added some more tests to cover for all operators in the context.