### PR TITLE
feat: add fixer for use-lifecycle-interface

### DIFF
--- a/src/utils/helper-functions/guards.ts
+++ b/src/utils/helper-functions/guards.ts
@@ -37,3 +37,19 @@ export function isExpressionStatement(
 ): node is TSESTree.ExpressionStatement {
   return node.type === AST_NODE_TYPES.ExpressionStatement
 }
+
+export function isImportDeclaration(
+  node: TSESTree.Node,
+): node is TSESTree.ImportDeclaration {
+  return node.type === 'ImportDeclaration'
+}
+
+export function isImportSpecifier(
+  node: TSESTree.Node,
+): node is TSESTree.ImportSpecifier {
+  return node.type === 'ImportSpecifier'
+}
+
+export function isProgram(node: TSESTree.Node): node is TSESTree.Program {
+  return node.type === 'Program'
+}

--- a/src/utils/helper-functions/utils.ts
+++ b/src/utils/helper-functions/utils.ts
@@ -1,5 +1,10 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils'
-import { isClassDeclaration } from './guards'
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils'
+import {
+  isClassDeclaration,
+  isImportDeclaration,
+  isImportSpecifier,
+  isProgram,
+} from './guards'
 
 export function findClassDeclarationNode(
   node: TSESTree.Node,
@@ -9,4 +14,65 @@ export function findClassDeclarationNode(
   }
   if (!node.parent) return null
   return findClassDeclarationNode(node.parent)
+}
+
+export function findImportDeclarationNode(
+  node: TSESTree.Node,
+  module: string,
+): TSESTree.ImportDeclaration | undefined {
+  if (isProgram(node)) {
+    return node.body.find(
+      (node) => isImportDeclaration(node) && node.source.value === module,
+    ) as TSESTree.ImportDeclaration | undefined
+  }
+  if (!node.parent) return undefined
+  return findImportDeclarationNode(node.parent, module)
+}
+
+export function getConditionalImportFix(
+  fixer: TSESLint.RuleFixer,
+  importDeclaration: TSESTree.ImportDeclaration | undefined,
+  importSpecifier: string,
+  modulePath: string,
+): TSESLint.RuleFix[] {
+  if (importDeclaration && hasImport(importDeclaration, importSpecifier)) {
+    return []
+  }
+
+  if (!importDeclaration?.specifiers.length) {
+    return [
+      fixer.insertTextAfterRange(
+        [0, 0],
+        `import { ${importSpecifier} } from '${modulePath}';\n`,
+      ),
+    ]
+  }
+
+  const lastImportSpecifier = getLast(importDeclaration.specifiers)
+
+  return [fixer.insertTextAfter(lastImportSpecifier, `, ${importSpecifier}`)]
+}
+
+export function getImplementsSchemaFixer(
+  { id, implements: implementz }: TSESTree.ClassDeclaration,
+  interfaceName: string,
+) {
+  const [implementsNodeReplace, implementsTextReplace] = implementz
+    ? [getLast(implementz), `, ${interfaceName}`]
+    : [id as TSESTree.Identifier, ` implements ${interfaceName}`]
+
+  return { implementsNodeReplace, implementsTextReplace } as const
+}
+
+export function getLast<T extends readonly unknown[]>(items: T): T[number] {
+  return items.slice(-1)[0]
+}
+
+export function hasImport(
+  { specifiers }: TSESTree.ImportDeclaration,
+  importSpecifier: string,
+): boolean {
+  return specifiers
+    .filter(isImportSpecifier)
+    .some(({ imported: { name } }) => name === importSpecifier)
 }

--- a/tests/rules/use-lifecycle-interface.test.ts
+++ b/tests/rules/use-lifecycle-interface.test.ts
@@ -42,7 +42,7 @@ ruleTester().run(ruleName, rule, {
       }
     `,
     `
-     class EffectWithIdentifier implements OnIdentifyEffects {
+      class EffectWithIdentifier implements OnIdentifyEffects {
         constructor(private effectIdentifier: string) {}
         ngrxOnIdentifyEffects() {
           return this.effectIdentifier;
@@ -64,29 +64,94 @@ ruleTester().run(ruleName, rule, {
     fromFixture(
       stripIndent`
         class UserEffects {
-          ngrxOnInitEffects() {
-          ~~~~~~~~~~~~~~~~~   [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
-          }
+          ngrxOnInitEffects() {}
+          ~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
         }
       `,
+      {
+        output: stripIndent`
+          import { OnInitEffects } from '@ngrx/effects';
+          class UserEffects implements OnInitEffects {
+            ngrxOnInitEffects() {}
+          }
+        `,
+      },
     ),
     fromFixture(
       stripIndent`
         class UserEffects {
-          ngrxOnIdentifyEffects() {
-          ~~~~~~~~~~~~~~~~~~~~~   [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
-          }
+          ngrxOnIdentifyEffects() {}
+          ~~~~~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
         }
       `,
+      {
+        output: stripIndent`
+          import { OnIdentifyEffects } from '@ngrx/effects';
+          class UserEffects implements OnIdentifyEffects {
+            ngrxOnIdentifyEffects() {}
+          }
+        `,
+      },
     ),
     fromFixture(
       stripIndent`
+        import { Injectable } from '@angular/core'
         class UserEffects {
-          ngrxOnRunEffects() {
-          ~~~~~~~~~~~~~~~~   [${messageId} { "interfaceName": "OnRunEffects", "methodName": "ngrxOnRunEffects" }]
-          }
+          ngrxOnRunEffects() {}
+          ~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnRunEffects", "methodName": "ngrxOnRunEffects" }]
         }
       `,
+      {
+        output: stripIndent`
+          import { OnRunEffects } from '@ngrx/effects';
+          import { Injectable } from '@angular/core'
+          class UserEffects implements OnRunEffects {
+            ngrxOnRunEffects() {}
+          }
+        `,
+      },
+    ),
+    fromFixture(
+      stripIndent`
+        import { OnInitEffects } from '@ngrx/effects';
+        class UserEffects {
+          ngrxOnInitEffects() {}
+          ~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
+        }
+      `,
+      {
+        output: stripIndent`
+          import { OnInitEffects } from '@ngrx/effects';
+          class UserEffects implements OnInitEffects {
+            ngrxOnInitEffects() {}
+          }
+        `,
+      },
+    ),
+    fromFixture(
+      stripIndent`
+        import { OnInitEffects, OnRunEffects } from '@ngrx/effects';
+        class UserEffects implements OnInitEffects, OnRunEffects {
+          ngrxOnInitEffects() {}
+
+          ngrxOnIdentifyEffects() {}
+          ~~~~~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
+
+          ngrxOnRunEffects() {}
+        }
+      `,
+      {
+        output: stripIndent`
+          import { OnInitEffects, OnRunEffects, OnIdentifyEffects } from '@ngrx/effects';
+          class UserEffects implements OnInitEffects, OnRunEffects, OnIdentifyEffects {
+            ngrxOnInitEffects() {}
+
+            ngrxOnIdentifyEffects() {}
+
+            ngrxOnRunEffects() {}
+          }
+        `,
+      },
     ),
   ],
 })


### PR DESCRIPTION
This PR aims to add a fixer for `use-lifecycle-interface`.

**Before**:
```ts
class UserEffects {
  ngrxOnInitEffects() {}
}
```

**After (--fix)**:
```ts
import { OnInitEffects } from '@ngrx/effects';
class UserEffects implements OnInitEffects {
  ngrxOnInitEffects() {}
}
```