### PR TITLE
feat: add fixer for no-dispatch-in-effects

### DIFF
--- a/src/rules/no-dispatch-in-effects.ts
+++ b/src/rules/no-dispatch-in-effects.ts
@@ -4,8 +4,11 @@ import { dispatchInEffects, docsUrl } from '../utils'
 
 export const ruleName = 'no-dispatch-in-effects'
 
-export const messageId = 'NoDispatchInEffects'
-export type MessageIds = typeof messageId
+export const noDispatchInEffects = 'noDispatchInEffects'
+export const noDispatchInEffectsSuggest = 'noDispatchInEffectsSuggest'
+export type MessageIds =
+  | typeof noDispatchInEffects
+  | typeof noDispatchInEffectsSuggest
 
 type Options = []
 
@@ -20,7 +23,9 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      [messageId]: 'Calling `store.dispatch` in an Effect is forbidden',
+      [noDispatchInEffects]:
+        'Calling `store.dispatch` in an Effect is forbidden',
+      [noDispatchInEffectsSuggest]: 'Remove `store.dispatch`',
     },
   },
   defaultOptions: [],
@@ -28,8 +33,14 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     return {
       [dispatchInEffects](node: TSESTree.CallExpression) {
         context.report({
+          suggest: [
+            {
+              fix: (fixer) => fixer.remove(node),
+              messageId: noDispatchInEffectsSuggest,
+            },
+          ],
           node,
-          messageId,
+          messageId: noDispatchInEffects,
         })
       },
     }


### PR DESCRIPTION
I went with a _suggest_ instead of _fix_ in this case because although it does not produce invalid code, it can cause some unexpected behavior if for example someone sets `dispatch: false` and still calls `store$.dispatch` manually (as in the test), there may be breaks in the expected flow.