### PR TITLE
fix: lint for store or store$

### DIFF
--- a/scripts/generate-config.ts
+++ b/scripts/generate-config.ts
@@ -10,7 +10,7 @@ const CONFIG_DIRECTORY = './src/configs/'
 
 const recommendedRules = Object.entries(rules).reduce(
   (rules, [ruleName, rule]) => {
-    if (rule.meta.docs.recommended) {
+    if (rule.meta.docs?.recommended) {
       rules[`${RULE_NAME_PREFIX}${ruleName}`] = rule.meta.docs.recommended
     }
     return rules

--- a/src/rules/avoid-combining-selectors.ts
+++ b/src/rules/avoid-combining-selectors.ts
@@ -5,6 +5,7 @@ import {
   isCallExpression,
   isMemberExpression,
   isIdentifier,
+  DEFAULT_STORE_NAMES,
 } from '../utils'
 
 export const ruleName = 'avoid-combining-selectors'
@@ -42,7 +43,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
             isMemberExpression(p.callee) &&
             isMemberExpression(p.callee.object) &&
             isIdentifier(p.callee.object.property) &&
-            p.callee.object.property.name === 'store' &&
+            DEFAULT_STORE_NAMES.includes(p.callee.object.property.name) &&
             isIdentifier(p.callee.property) &&
             p.callee.property.name === 'select',
         )

--- a/src/rules/avoid-mapping-selectors.ts
+++ b/src/rules/avoid-mapping-selectors.ts
@@ -1,6 +1,11 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { docsUrl, isCallExpression, isIdentifier } from '../utils'
+import {
+  docsUrl,
+  isCallExpression,
+  isIdentifier,
+  readNgRxStoreNameFromSettings,
+} from '../utils'
 
 export const ruleName = 'avoid-mapping-selectors'
 
@@ -28,7 +33,9 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      [`CallExpression[callee.object.callee.object.property.name='store'][callee.object.callee.property.name='select'][callee.property.name='pipe']`](
+      [`CallExpression[callee.object.callee.object.property.name=${readNgRxStoreNameFromSettings(
+        context.settings,
+      )}][callee.object.callee.property.name='select'][callee.property.name='pipe']`](
         node: TSESTree.CallExpression,
       ) {
         const violations = node.arguments.filter(

--- a/src/rules/no-dispatch-in-effects.ts
+++ b/src/rules/no-dispatch-in-effects.ts
@@ -1,6 +1,10 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { dispatchInEffects, docsUrl } from '../utils'
+import {
+  dispatchInEffects,
+  docsUrl,
+  readNgRxStoreNameFromSettings,
+} from '../utils'
 
 export const ruleName = 'no-dispatch-in-effects'
 
@@ -26,7 +30,9 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      [dispatchInEffects](node: TSESTree.CallExpression) {
+      [dispatchInEffects(readNgRxStoreNameFromSettings(context.settings))](
+        node: TSESTree.CallExpression,
+      ) {
         context.report({
           node,
           messageId,

--- a/src/rules/select-style.ts
+++ b/src/rules/select-style.ts
@@ -1,6 +1,11 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { docsUrl, pipeableSelect, storeSelect } from '../utils'
+import {
+  docsUrl,
+  pipeableSelect,
+  readNgRxStoreNameFromSettings,
+  storeSelect,
+} from '../utils'
 
 export const ruleName = 'select-style'
 
@@ -54,7 +59,9 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
           })
         }
       },
-      [storeSelect](node: TSESTree.Identifier) {
+      [storeSelect(readNgRxStoreNameFromSettings(context.settings))](
+        node: TSESTree.Identifier,
+      ) {
         if (mode === OPERATOR) {
           context.report({
             node,

--- a/src/utils/helper-functions/index.ts
+++ b/src/utils/helper-functions/index.ts
@@ -1,4 +1,5 @@
 export * from './docs'
 export * from './guards'
+export * from './settings'
 export * from './typecheck'
 export * from './utils'

--- a/src/utils/helper-functions/settings.ts
+++ b/src/utils/helper-functions/settings.ts
@@ -1,7 +1,14 @@
-const defaultStoreName = '/^(store|store\\$)?$/'
+export const DEFAULT_STORE_NAMES = ['store', 'store$']
+
+const defaultStoreNamesRegexp = `/^(${DEFAULT_STORE_NAMES.join('|').replace(
+  '$',
+  '\\\\$',
+)})?$/`
 
 export function readNgRxStoreNameFromSettings(
   settings: Record<string, unknown>,
 ): string {
-  return (settings.ngrxStoreName as string | undefined) || defaultStoreName
+  return (
+    (settings.ngrxStoreName as string | undefined) || defaultStoreNamesRegexp
+  )
 }

--- a/src/utils/helper-functions/settings.ts
+++ b/src/utils/helper-functions/settings.ts
@@ -1,0 +1,7 @@
+const defaultStoreName = '/^(store|store\\$)?$/'
+
+export function readNgRxStoreNameFromSettings(
+  settings: Record<string, unknown>,
+): string {
+  return (settings.ngrxStoreName as string | undefined) || defaultStoreName
+}

--- a/src/utils/helper-functions/settings.ts
+++ b/src/utils/helper-functions/settings.ts
@@ -3,7 +3,7 @@ export const DEFAULT_STORE_NAMES = ['store', 'store$']
 const defaultStoreNamesRegexp = `/^(${DEFAULT_STORE_NAMES.join('|').replace(
   '$',
   '\\\\$',
-)})?$/`
+)})$/`
 
 export function readNgRxStoreNameFromSettings(
   settings: Record<string, unknown>,

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -25,10 +25,10 @@ export const pipeableSelect = `CallExpression[callee.property.name="pipe"] CallE
 export const storeSelect = (storeName: string) =>
   `CallExpression[callee.object.property.name=${storeName}][callee.property.name='select']`
 
-export const select = (storeName: string) =>
-  `${pipeableSelect} Literal, ${storeSelect(
-    storeName,
-  )} Literal, ${pipeableSelect} ArrowFunctionExpression, ${storeSelect} ArrowFunctionExpression`
+export const select = (storeName: string) => {
+  const storeSelectName = storeSelect(storeName)
+  return `${pipeableSelect} Literal, ${storeSelectName} Literal, ${pipeableSelect} ArrowFunctionExpression, ${storeSelectName} ArrowFunctionExpression`
+}
 
 export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'] CallExpression[callee.name='on'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`
 

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -9,7 +9,8 @@ export const actionCreatorPropsComputed = `${actionCreatorProps} > TSTypeParamet
 
 export const constructorExit = `MethodDefinition[kind='constructor']:exit`
 
-export const dispatchInEffects = `ClassProperty > CallExpression:has(Identifier[name="createEffect"]) CallExpression > MemberExpression:has(Identifier[name="dispatch"]):has(MemberExpression > Identifier[name="store"])`
+export const dispatchInEffects = (storeName: string) =>
+  `ClassProperty > CallExpression:has(Identifier[name="createEffect"]) CallExpression > MemberExpression:has(Identifier[name="dispatch"]):has(MemberExpression > Identifier[name=${storeName}])`
 
 export const injectedStore = `MethodDefinition[kind='constructor'] Identifier[typeAnnotation.typeAnnotation.typeName.name="Store"]`
 export const typedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name="Store"][typeParameters.params]`
@@ -21,9 +22,13 @@ export const ngModuleProviders = `${ngModuleDecorator} ObjectExpression Property
 export const ngModuleImports = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='EffectsModule'][callee.property.name=/forRoot|forFeature/] ArrayExpression > Identifier`
 
 export const pipeableSelect = `CallExpression[callee.property.name="pipe"] CallExpression[callee.name="select"]`
-export const storeSelect = `CallExpression[callee.object.property.name='store'][callee.property.name='select']`
+export const storeSelect = (storeName: string) =>
+  `CallExpression[callee.object.property.name=${storeName}][callee.property.name='select']`
 
-export const select = `${pipeableSelect} Literal, ${storeSelect} Literal, ${pipeableSelect} ArrowFunctionExpression, ${storeSelect} ArrowFunctionExpression`
+export const select = (storeName: string) =>
+  `${pipeableSelect} Literal, ${storeSelect(
+    storeName,
+  )} Literal, ${pipeableSelect} ArrowFunctionExpression, ${storeSelect} ArrowFunctionExpression`
 
 export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'] CallExpression[callee.name='on'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`
 

--- a/tests/rules/select-style.test.ts
+++ b/tests/rules/select-style.test.ts
@@ -12,6 +12,7 @@ import { ruleTester } from '../utils'
 ruleTester().run(ruleName, rule, {
   valid: [
     `this.store.select(selector);`,
+    `this.store$.select(selector);`,
     {
       code: `this.store.pipe(select(selector));`,
       options: [{ mode: OPERATOR }],
@@ -19,6 +20,12 @@ ruleTester().run(ruleName, rule, {
     {
       code: `this.store.select(selector);`,
       options: [{ mode: METHOD }],
+    },
+    {
+      code: `this.anotherName.select(selector);`,
+      settings: {
+        ngrxStoreName: 'anotherName',
+      },
     },
   ],
   invalid: [


### PR DESCRIPTION
Storename is customizable via ESLint shared settings

@rafaelss95 what do you think?
I think this is the easiest way to allow a different name for `store` (or `store$`).
The harder way would be to get the store name at runtime and somehow query for "invalid" code, this would mean we can't use the esquery syntax anymore, as far as I know.