### PR TITLE
fix(select-style): simplify and unify settings settings

### DIFF
--- a/docs/rules/select-style.md
+++ b/docs/rules/select-style.md
@@ -29,12 +29,13 @@ export class Component {
 ## Rule Config
 
 To configure this rule you can change the preferred `mode` of the selectors, the allowed values are `method` and `operator`.
+The default is `method`.
 
 To prefer the **method** syntax (`this.store.select(selector)`) use:
 
 ```json
 "rules": {
-  "ngrx/select-style": ["warn", { "mode": "method" }]
+  "ngrx/select-style": ["warn", "method"]
 }
 ```
 
@@ -42,6 +43,6 @@ To prefer the **operator** syntax (`this.store.pipe(select(selector))`) use:
 
 ```json
 "rules": {
-  "ngrx/select-style": ["warn", { "mode": "operator" }]
+  "ngrx/select-style": ["warn", "operator"]
 }
 ```

--- a/src/rules/store/select-style.ts
+++ b/src/rules/store/select-style.ts
@@ -18,7 +18,7 @@ export type MessageIds =
 export const OPERATOR = 'operator'
 export const METHOD = 'method'
 
-type Options = [{ mode: string }]
+type Options = [typeof OPERATOR | typeof METHOD]
 
 export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   name: path.parse(__filename).name,
@@ -31,24 +31,20 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     },
     schema: [
       {
-        type: 'object',
-        properties: {
-          mode: {
-            enum: [OPERATOR, METHOD],
-          },
-        },
+        type: 'string',
+        enum: [OPERATOR, METHOD],
         additionalProperties: false,
       },
     ],
     messages: {
       [methodSelectMessageId]:
-        'Selectors should be used with select method: this.store.select(selector)',
+        'Selectors should be used with select method, `this.store.select(selector)`',
       [operatorSelectMessageId]:
-        'Selectors should be used with the pipeable operator: this.store.pipe(select(selector))',
+        'Selectors should be used with the pipeable operator, `this.store.pipe(select(selector))`',
     },
   },
-  defaultOptions: [{ mode: METHOD }],
-  create: (context, [{ mode }]) => {
+  defaultOptions: [METHOD],
+  create: (context, [mode]) => {
     const storeName = findNgRxStoreName(context)
     if (!storeName) return {}
 

--- a/tests/rules/select-style.test.ts
+++ b/tests/rules/select-style.test.ts
@@ -36,7 +36,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
         constructor(private store: Store){}
       }
       `,
-      options: [{ mode: OPERATOR }],
+      options: [OPERATOR],
     },
     {
       code: `
@@ -47,7 +47,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
         constructor(private store: Store){}
       }
       `,
-      options: [{ mode: METHOD }],
+      options: [METHOD],
     },
   ],
   invalid: [
@@ -101,7 +101,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
         }
       `,
       {
-        options: [{ mode: METHOD }],
+        options: [METHOD],
       },
     ),
     fromFixture(
@@ -116,7 +116,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
 
       `,
       {
-        options: [{ mode: OPERATOR }],
+        options: [OPERATOR],
       },
     ),
   ],


### PR DESCRIPTION
Define the preferred way with a string instead of an object.

BEFORE:

```json
"rules": {
  "ngrx/select-style": ["warn", { "mode": "operator" }]
}
```

AFTER:

```json
"rules": {
  "ngrx/select-style": ["warn", "operator"]
}
```