### PR TITLE
style: enforce consistent type-import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     extraFileExtensions: ['.json'],
   },
   rules: {
+    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "husky": "^7.0.1",
         "lint-staged": "^11.1.2",
         "prettier": "^2.3.2",
+        "prettier-plugin-organize-imports": "^2.3.3",
         "rimraf": "^3.0.2",
         "ts-node": "^9.0.0",
         "typescript": "~4.3.5",
@@ -3976,6 +3977,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.3.tgz",
+      "integrity": "sha512-PBOwQ8vEIB2b7B3gCuBG7D+dqsr1fsTR4TSAjNacRVdHJrD0yzgz9grOLPSyfwJm+NUTZLyWeHoZ+1mHaUrk+g==",
+      "dev": true,
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9"
       }
     },
     "node_modules/progress": {
@@ -8468,6 +8479,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-organize-imports": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.3.tgz",
+      "integrity": "sha512-PBOwQ8vEIB2b7B3gCuBG7D+dqsr1fsTR4TSAjNacRVdHJrD0yzgz9grOLPSyfwJm+NUTZLyWeHoZ+1mHaUrk+g==",
+      "dev": true,
+      "requires": {}
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "husky": "^7.0.1",
     "lint-staged": "^11.1.2",
     "prettier": "^2.3.2",
+    "prettier-plugin-organize-imports": "^2.3.3",
     "rimraf": "^3.0.2",
     "ts-node": "^9.0.0",
     "typescript": "~4.3.5",

--- a/scripts/generate-readme.ts
+++ b/scripts/generate-readme.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, readFileSync } from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import { EOL } from 'os'
 import { format, resolveConfig } from 'prettier'
 import { rules } from '../src/rules'

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,5 +1,4 @@
 import type { TSESLint } from '@typescript-eslint/experimental-utils'
-
 import { traverseFolder } from '../utils'
 
 // Copied from https://github.com/jest-community/eslint-plugin-jest/blob/main/src/index.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { rules } from './rules'
 import { configs } from './configs'
+import { rules } from './rules'
 
 export = {
   rules,

--- a/src/rules/component-store/updater-explicit-return-type.ts
+++ b/src/rules/component-store/updater-explicit-return-type.ts
@@ -1,5 +1,6 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import { docsUrl, findNgRxComponentStoreName } from '../../utils'
 

--- a/src/rules/component-store/updater-explicit-return-type.ts
+++ b/src/rules/component-store/updater-explicit-return-type.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl, findNgRxComponentStoreName } from '../../utils'
 
 export const messageId = 'updaterExplicitReturnType'

--- a/src/rules/effects/avoid-cyclic-effects.ts
+++ b/src/rules/effects/avoid-cyclic-effects.ts
@@ -1,6 +1,8 @@
-import ts from 'typescript'
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
+import { getTypeServices } from 'eslint-etc'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+import ts from 'typescript'
 
 import {
   createEffectExpression,
@@ -10,7 +12,6 @@ import {
   isIdentifier,
   isTypeReference,
 } from '../../utils'
-import { getTypeServices } from 'eslint-etc'
 
 export const messageId = 'avoidCyclicEffects'
 export type MessageIds = typeof messageId

--- a/src/rules/effects/avoid-cyclic-effects.ts
+++ b/src/rules/effects/avoid-cyclic-effects.ts
@@ -3,7 +3,6 @@ import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import { getTypeServices } from 'eslint-etc'
 import path from 'path'
 import ts from 'typescript'
-
 import {
   createEffectExpression,
   docsUrl,

--- a/src/rules/effects/no-dispatch-in-effects.ts
+++ b/src/rules/effects/no-dispatch-in-effects.ts
@@ -1,5 +1,6 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import { dispatchInEffects, docsUrl, findNgRxStoreName } from '../../utils'
 

--- a/src/rules/effects/no-dispatch-in-effects.ts
+++ b/src/rules/effects/no-dispatch-in-effects.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { dispatchInEffects, docsUrl, findNgRxStoreName } from '../../utils'
 
 export const messageId = 'NoDispatchInEffects'

--- a/src/rules/effects/no-effect-decorator-and-creator.ts
+++ b/src/rules/effects/no-effect-decorator-and-creator.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl, effectCreator, effectDecorator } from '../../utils'
 
 export const messageId = 'noEffectDecoratorAndCreator'

--- a/src/rules/effects/no-effect-decorator-and-creator.ts
+++ b/src/rules/effects/no-effect-decorator-and-creator.ts
@@ -1,7 +1,8 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { effectCreator, effectDecorator, docsUrl } from '../../utils'
+import { docsUrl, effectCreator, effectDecorator } from '../../utils'
 
 export const messageId = 'noEffectDecoratorAndCreator'
 export type MessageIds = typeof messageId

--- a/src/rules/effects/no-effect-decorator.ts
+++ b/src/rules/effects/no-effect-decorator.ts
@@ -1,6 +1,7 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESLint } from '@typescript-eslint/experimental-utils'
-import type { TSESTree } from '@typescript-eslint/experimental-utils'
+
 import {
   classPropertyWithEffectDecorator,
   docsUrl,

--- a/src/rules/effects/no-effect-decorator.ts
+++ b/src/rules/effects/no-effect-decorator.ts
@@ -1,7 +1,6 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   classPropertyWithEffectDecorator,
   docsUrl,

--- a/src/rules/effects/no-effects-in-providers.ts
+++ b/src/rules/effects/no-effects-in-providers.ts
@@ -1,11 +1,12 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import {
+  docsUrl,
   ngModuleDecorator,
   ngModuleImports,
   ngModuleProviders,
-  docsUrl,
 } from '../../utils'
 
 export const messageId = 'noEffectsInProviders'

--- a/src/rules/effects/no-effects-in-providers.ts
+++ b/src/rules/effects/no-effects-in-providers.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   ngModuleDecorator,

--- a/src/rules/effects/no-multiple-actions-in-effects.ts
+++ b/src/rules/effects/no-multiple-actions-in-effects.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   effectsImplicitReturn,

--- a/src/rules/effects/no-multiple-actions-in-effects.ts
+++ b/src/rules/effects/no-multiple-actions-in-effects.ts
@@ -1,10 +1,11 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import {
+  docsUrl,
   effectsImplicitReturn,
   effectsReturn,
-  docsUrl,
   typecheck,
 } from '../../utils'
 

--- a/src/rules/effects/prefer-concat-latest-from.ts
+++ b/src/rules/effects/prefer-concat-latest-from.ts
@@ -1,11 +1,12 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import {
-  docsUrl,
   createEffectExpression,
-  MODULE_PATHS,
+  docsUrl,
   getConditionalImportFix,
+  MODULE_PATHS,
 } from '../../utils'
 
 export const messageId = 'preferConcatLatestFrom'

--- a/src/rules/effects/prefer-concat-latest-from.ts
+++ b/src/rules/effects/prefer-concat-latest-from.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   createEffectExpression,
   docsUrl,

--- a/src/rules/effects/prefer-effect-callback-in-block-statement.ts
+++ b/src/rules/effects/prefer-effect-callback-in-block-statement.ts
@@ -1,7 +1,8 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { docsUrl, createEffectBody, isCallExpression } from '../../utils'
+import { createEffectBody, docsUrl, isCallExpression } from '../../utils'
 
 export const messageId = 'preferEffectCallbackInBlockStatement'
 

--- a/src/rules/effects/prefer-effect-callback-in-block-statement.ts
+++ b/src/rules/effects/prefer-effect-callback-in-block-statement.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { createEffectBody, docsUrl, isCallExpression } from '../../utils'
 
 export const messageId = 'preferEffectCallbackInBlockStatement'

--- a/src/rules/effects/use-effects-lifecycle-interface.ts
+++ b/src/rules/effects/use-effects-lifecycle-interface.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   findClassDeclarationNode,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import { traverseFolder } from '../utils'
-import { RuleModule } from '../utils/types'
+import type { RuleModule } from '../utils/types'
 
 // Copied from https://github.com/jest-community/eslint-plugin-jest/blob/main/src/index.ts
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-
 import { traverseFolder } from '../utils'
 import type { RuleModule } from '../utils/types'
 

--- a/src/rules/store/avoid-combining-selectors.ts
+++ b/src/rules/store/avoid-combining-selectors.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   findNgRxStoreName,

--- a/src/rules/store/avoid-combining-selectors.ts
+++ b/src/rules/store/avoid-combining-selectors.ts
@@ -1,11 +1,12 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import {
   docsUrl,
   findNgRxStoreName,
-  storeSelect,
   storeExpression,
+  storeSelect,
 } from '../../utils'
 
 export const messageId = 'avoidCombiningSelectors'

--- a/src/rules/store/avoid-dispatching-multiple-actions-sequentially.ts
+++ b/src/rules/store/avoid-dispatching-multiple-actions-sequentially.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   actionDispatch,
   docsUrl,

--- a/src/rules/store/avoid-dispatching-multiple-actions-sequentially.ts
+++ b/src/rules/store/avoid-dispatching-multiple-actions-sequentially.ts
@@ -1,11 +1,12 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import {
   actionDispatch,
   docsUrl,
-  isExpressionStatement,
   findNgRxStoreName,
+  isExpressionStatement,
 } from '../../utils'
 
 export const messageId = 'avoidDispatchingMultipleActionsSequentially'

--- a/src/rules/store/avoid-duplicate-actions-in-reducer.ts
+++ b/src/rules/store/avoid-duplicate-actions-in-reducer.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl, isIdentifier } from '../../utils'
 
 export const messageId = 'avoidDuplicateActionsInReducer'

--- a/src/rules/store/avoid-duplicate-actions-in-reducer.ts
+++ b/src/rules/store/avoid-duplicate-actions-in-reducer.ts
@@ -1,5 +1,7 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+
 import { docsUrl, isIdentifier } from '../../utils'
 
 export const messageId = 'avoidDuplicateActionsInReducer'

--- a/src/rules/store/avoid-mapping-selectors.ts
+++ b/src/rules/store/avoid-mapping-selectors.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   findNgRxStoreName,

--- a/src/rules/store/avoid-mapping-selectors.ts
+++ b/src/rules/store/avoid-mapping-selectors.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
 
 import {

--- a/src/rules/store/good-action-hygiene.ts
+++ b/src/rules/store/good-action-hygiene.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { actionCreatorWithLiteral, docsUrl } from '../../utils'
 
 export const messageId = 'goodActionHygiene'

--- a/src/rules/store/good-action-hygiene.ts
+++ b/src/rules/store/good-action-hygiene.ts
@@ -1,5 +1,6 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import { actionCreatorWithLiteral, docsUrl } from '../../utils'
 

--- a/src/rules/store/no-multiple-global-stores.ts
+++ b/src/rules/store/no-multiple-global-stores.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { constructorExit, docsUrl, injectedStore } from '../../utils'
 
 export const messageId = 'noMultipleGlobalStores'

--- a/src/rules/store/no-multiple-global-stores.ts
+++ b/src/rules/store/no-multiple-global-stores.ts
@@ -1,7 +1,8 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { constructorExit, injectedStore, docsUrl } from '../../utils'
+import { constructorExit, docsUrl, injectedStore } from '../../utils'
 
 export const messageId = 'noMultipleGlobalStores'
 export type MessageIds = typeof messageId

--- a/src/rules/store/no-reducer-in-key-names.ts
+++ b/src/rules/store/no-reducer-in-key-names.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   actionReducerMap,
   docsUrl,

--- a/src/rules/store/no-reducer-in-key-names.ts
+++ b/src/rules/store/no-reducer-in-key-names.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
 
 import {

--- a/src/rules/store/no-store-subscription.ts
+++ b/src/rules/store/no-store-subscription.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   findNgRxStoreName,

--- a/src/rules/store/no-store-subscription.ts
+++ b/src/rules/store/no-store-subscription.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
 
 import {

--- a/src/rules/store/no-typed-global-store.ts
+++ b/src/rules/store/no-typed-global-store.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl, typedStore } from '../../utils'
 
 export const messageId = 'noTypedStore'

--- a/src/rules/store/no-typed-global-store.ts
+++ b/src/rules/store/no-typed-global-store.ts
@@ -1,7 +1,8 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { typedStore, docsUrl } from '../../utils'
+import { docsUrl, typedStore } from '../../utils'
 
 export const messageId = 'noTypedStore'
 export const noTypedStoreSuggest = 'noTypedStoreSuggest'

--- a/src/rules/store/on-function-explicit-return-type.ts
+++ b/src/rules/store/on-function-explicit-return-type.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl, onFunctionWithoutType } from '../../utils'
 
 export const messageId = 'onFunctionExplicitReturnType'

--- a/src/rules/store/on-function-explicit-return-type.ts
+++ b/src/rules/store/on-function-explicit-return-type.ts
@@ -1,7 +1,8 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { onFunctionWithoutType, docsUrl } from '../../utils'
+import { docsUrl, onFunctionWithoutType } from '../../utils'
 
 export const messageId = 'onFunctionExplicitReturnType'
 export type MessageIds = typeof messageId

--- a/src/rules/store/prefer-inline-action-props.ts
+++ b/src/rules/store/prefer-inline-action-props.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { actionCreatorPropsComputed, docsUrl } from '../../utils'
 
 export const preferInlineActionProps = 'preferInlineActionProps'

--- a/src/rules/store/prefer-inline-action-props.ts
+++ b/src/rules/store/prefer-inline-action-props.ts
@@ -1,6 +1,6 @@
-import path from 'path'
-import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
+import path from 'path'
 
 import { actionCreatorPropsComputed, docsUrl } from '../../utils'
 

--- a/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
+++ b/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
@@ -1,7 +1,8 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { docsUrl, isTSTypeReference, isIdentifier } from '../../utils'
+import { docsUrl, isIdentifier, isTSTypeReference } from '../../utils'
 
 export const preferOneGenericInCreateForFeatureSelector =
   'preferOneGenericInCreateForFeatureSelector'

--- a/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
+++ b/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl, isIdentifier, isTSTypeReference } from '../../utils'
 
 export const preferOneGenericInCreateForFeatureSelector =

--- a/src/rules/store/prefix-selectors-with-select.ts
+++ b/src/rules/store/prefix-selectors-with-select.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl } from '../../utils'
 
 export const messageId = 'prefixSelectorsWithSelect'

--- a/src/rules/store/prefix-selectors-with-select.ts
+++ b/src/rules/store/prefix-selectors-with-select.ts
@@ -1,5 +1,6 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import { docsUrl } from '../../utils'
 

--- a/src/rules/store/select-style.ts
+++ b/src/rules/store/select-style.ts
@@ -1,10 +1,11 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
 import {
   docsUrl,
-  pipeableSelect,
   findNgRxStoreName,
+  pipeableSelect,
   storeSelect,
 } from '../../utils'
 

--- a/src/rules/store/select-style.ts
+++ b/src/rules/store/select-style.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   findNgRxStoreName,

--- a/src/rules/store/use-consistent-global-store-name.ts
+++ b/src/rules/store/use-consistent-global-store-name.ts
@@ -1,7 +1,8 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
 
-import { injectedStore, docsUrl } from '../../utils'
+import { docsUrl, injectedStore } from '../../utils'
 
 export const messageId = 'useConsistentGlobalStoreName'
 export type MessageIds = typeof messageId

--- a/src/rules/store/use-consistent-global-store-name.ts
+++ b/src/rules/store/use-consistent-global-store-name.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import { docsUrl, injectedStore } from '../../utils'
 
 export const messageId = 'useConsistentGlobalStoreName'

--- a/src/rules/store/use-selector-in-select.ts
+++ b/src/rules/store/use-selector-in-select.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-
 import {
   docsUrl,
   findNgRxStoreName,

--- a/src/rules/store/use-selector-in-select.ts
+++ b/src/rules/store/use-selector-in-select.ts
@@ -1,5 +1,7 @@
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+
 import {
   docsUrl,
   findNgRxStoreName,

--- a/src/schematics/ng-add/index.ts
+++ b/src/schematics/ng-add/index.ts
@@ -1,4 +1,4 @@
-import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics'
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics'
 
 export default function (): Rule {
   return (host: Tree, context: SchematicContext) => {

--- a/src/utils/helper-functions/folder.ts
+++ b/src/utils/helper-functions/folder.ts
@@ -1,5 +1,5 @@
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
 
 export function* traverseFolder(
   folder: string,

--- a/src/utils/helper-functions/guards.ts
+++ b/src/utils/helper-functions/guards.ts
@@ -1,5 +1,6 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
-import ts from 'typescript'
+import type { TSESTree } from '@typescript-eslint/experimental-utils'
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils'
+import type ts from 'typescript'
 
 const isNodeOfType =
   <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -11,10 +11,10 @@ export const actionCreatorPropsComputed = `${actionCreatorProps} > TSTypeParamet
 export const constructorExit = `MethodDefinition[kind='constructor']:exit`
 
 export const dispatchInEffects = (storeName: string) =>
-  `ClassProperty > CallExpression:has(Identifier[name="createEffect"]) CallExpression > MemberExpression:has(Identifier[name="dispatch"]):has(MemberExpression > Identifier[name=${storeName}])`
+  `ClassProperty > CallExpression:has(Identifier[name='createEffect']) CallExpression > MemberExpression:has(Identifier[name='dispatch']):has(MemberExpression > Identifier[name='${storeName}'])`
 
-export const injectedStore = `MethodDefinition[kind='constructor'] Identifier[typeAnnotation.typeAnnotation.typeName.name="Store"]`
-export const typedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name="Store"][typeParameters.params]`
+export const injectedStore = `MethodDefinition[kind='constructor'] Identifier[typeAnnotation.typeAnnotation.typeName.name='Store']`
+export const typedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name='Store'][typeParameters.params]`
 
 export const ngModuleDecorator = `ClassDeclaration > Decorator > CallExpression[callee.name='NgModule']`
 
@@ -23,10 +23,10 @@ export const ngModuleProviders = `${ngModuleDecorator} ObjectExpression Property
 export const ngModuleImports = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='EffectsModule'][callee.property.name=/forRoot|forFeature/] ArrayExpression > Identifier`
 
 export const actionDispatch = (storeName: string) =>
-  `ExpressionStatement > CallExpression:matches([callee.object.name=${storeName}][callee.property.name="dispatch"], [callee.object.object.type='ThisExpression'][callee.object.property.name=${storeName}][callee.property.name="dispatch"])`
+  `ExpressionStatement > CallExpression:matches([callee.object.name='${storeName}'][callee.property.name='dispatch'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'][callee.property.name='dispatch'])`
 
 export const storeExpression = (storeName: string) =>
-  `CallExpression:matches([callee.object.name=${storeName}], [callee.object.object.type='ThisExpression'][callee.object.property.name=${storeName}])`
+  `CallExpression:matches([callee.object.name='${storeName}'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'])`
 
 export const storeExpressionCallable = (storeName: string) =>
   `CallExpression:matches([callee.object.callee.object.name='${storeName}'], [callee.object.callee.object.object.type='ThisExpression'][callee.object.callee.object.property.name='${storeName}'])`

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils'
+import type { TSESLint } from '@typescript-eslint/experimental-utils'
 
 export type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
   meta: { module: string }

--- a/tests/exported-config.test.ts
+++ b/tests/exported-config.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'uvu'
-import * as assert from 'uvu/assert'
+import assert from 'uvu/assert'
 import plugin from '../src'
 
 test('exports all config', () => {

--- a/tests/exported-rules.test.ts
+++ b/tests/exported-rules.test.ts
@@ -1,7 +1,7 @@
+import * as path from 'path'
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import * as lib from '../src/rules'
-import * as path from 'path'
 import { traverseFolder } from '../src/utils'
 
 const rulesDirectory = path.join(__dirname, '../src/rules')

--- a/tests/exported-rules.test.ts
+++ b/tests/exported-rules.test.ts
@@ -1,6 +1,6 @@
-import * as path from 'path'
+import path from 'path'
 import { test } from 'uvu'
-import * as assert from 'uvu/assert'
+import assert from 'uvu/assert'
 import * as lib from '../src/rules'
 import { traverseFolder } from '../src/utils'
 

--- a/tests/rules/avoid-duplicate-actions-in-reducer.test.ts
+++ b/tests/rules/avoid-duplicate-actions-in-reducer.test.ts
@@ -1,6 +1,6 @@
-import path from 'path'
-import { fromFixture } from 'eslint-etc'
 import { stripIndent } from 'common-tags'
+import { fromFixture } from 'eslint-etc'
+import path from 'path'
 import rule, {
   messageId,
 } from '../../src/rules/store/avoid-duplicate-actions-in-reducer'

--- a/tests/rules/no-effect-decorator.test.ts
+++ b/tests/rules/no-effect-decorator.test.ts
@@ -1,8 +1,8 @@
 import { stripIndents } from 'common-tags'
 import { fromFixture } from 'eslint-etc'
 import path from 'path'
+import type { MessageIds } from '../../src/rules/effects/no-effect-decorator'
 import rule, {
-  MessageIds,
   noEffectDecorator,
   noEffectDecoratorSuggest,
 } from '../../src/rules/effects/no-effect-decorator'

--- a/tests/rules/prefer-concat-latest-from.test.ts
+++ b/tests/rules/prefer-concat-latest-from.test.ts
@@ -1,9 +1,9 @@
 import { stripIndent, stripIndents } from 'common-tags'
 import { fromFixture } from 'eslint-etc'
 import path from 'path'
+import type { MessageIds } from '../../src/rules/effects/prefer-concat-latest-from'
 import rule, {
   messageId,
-  MessageIds,
   messageIdSuggest,
 } from '../../src/rules/effects/prefer-concat-latest-from'
 import { ruleTester } from '../utils'

--- a/tests/rules/prefer-one-generic-in-create-for-feature-selector.test.ts
+++ b/tests/rules/prefer-one-generic-in-create-for-feature-selector.test.ts
@@ -1,8 +1,8 @@
 import { stripIndent } from 'common-tags'
 import { fromFixture } from 'eslint-etc'
 import path from 'path'
+import type { MessageIds } from '../../src/rules/store/prefer-one-generic-in-create-for-feature-selector'
 import rule, {
-  MessageIds,
   preferOneGenericInCreateForFeatureSelector,
   preferOneGenericInCreateForFeatureSelectorSuggest,
 } from '../../src/rules/store/prefer-one-generic-in-create-for-feature-selector'

--- a/tests/rules/select-style.test.ts
+++ b/tests/rules/select-style.test.ts
@@ -3,9 +3,9 @@ import { fromFixture } from 'eslint-etc'
 import path from 'path'
 import rule, {
   METHOD,
+  methodSelectMessageId,
   OPERATOR,
   operatorSelectMessageId,
-  methodSelectMessageId,
 } from '../../src/rules/store/select-style'
 import { ruleTester } from '../utils'
 

--- a/tests/schematics/ng-add.test.ts
+++ b/tests/schematics/ng-add.test.ts
@@ -1,10 +1,10 @@
-import { test } from 'uvu'
-import * as assert from 'uvu/assert'
 import { Tree } from '@angular-devkit/schematics'
 import {
   SchematicTestRunner,
   UnitTestTree,
 } from '@angular-devkit/schematics/testing'
+import { test } from 'uvu'
+import assert from 'uvu/assert'
 
 const schematicRunner = new SchematicTestRunner(
   'eslint-plugin-ngrx',

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path'
 import { TSESLint } from '@typescript-eslint/experimental-utils'
+import { resolve } from 'path'
 
 export function ruleTester() {
   return new TSESLint.RuleTester({


### PR DESCRIPTION
Currently we have incosistencies related to `type-only imports` vs `imports`. Using the rule [**`@typescript-eslint/consistent-type-imports`**](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md) we can now keep it consistent. 