### PR TITLE
refactor: add missing `suggestion` metadata

### DIFF
--- a/src/rules/effects/no-effect-decorator.ts
+++ b/src/rules/effects/no-effect-decorator.ts
@@ -32,6 +32,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       category: 'Best Practices',
       description: 'The createEffect creator function is preferred',
       recommended: 'warn',
+      suggestion: true,
     },
     fixable: 'code',
     schema: [],

--- a/src/rules/effects/prefer-concat-latest-from.ts
+++ b/src/rules/effects/prefer-concat-latest-from.ts
@@ -23,6 +23,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       description:
         'Use `concatLatestFrom` instead of `withLatestFrom` to prevent the selector from firing until the correct action is dispatched.',
       recommended: 'warn',
+      suggestion: true,
     },
     fixable: 'code',
     schema: [],

--- a/src/rules/store/no-typed-global-store.ts
+++ b/src/rules/store/no-typed-global-store.ts
@@ -17,6 +17,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       category: 'Best Practices',
       description: 'The global store should not be typed.',
       recommended: 'warn',
+      suggestion: true,
     },
     fixable: 'code',
     schema: [],

--- a/src/rules/store/prefer-inline-action-props.ts
+++ b/src/rules/store/prefer-inline-action-props.ts
@@ -20,6 +20,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       category: 'Best Practices',
       description: 'Prefer using inline types instead of interfaces/classes.',
       recommended: 'warn',
+      suggestion: true,
     },
     schema: [],
     messages: {

--- a/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
+++ b/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
@@ -21,6 +21,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       category: 'Best Practices',
       description: 'Prefer using a single generic to define the feature state.',
       recommended: 'warn',
+      suggestion: true,
     },
     schema: [],
     messages: {


### PR DESCRIPTION
This will also help to identificate which rules we need to migrate when update to [**`ESLint v8`**](https://eslint.org/blog/2021/08/eslint-v8.0.0-beta.0-released#breaking-changes), where the ~`suggestions`~ `hasSuggestions` will be required for rules that suggest something.