### PR TITLE
fix: ability to handle multiple imports

### DIFF
--- a/src/rules/effects/avoid-cyclic-effects.ts
+++ b/src/rules/effects/avoid-cyclic-effects.ts
@@ -86,8 +86,8 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       for (const actionType of operatorActionTypes) {
         if (pipeActionTypes.includes(actionType)) {
           context.report({
-            messageId,
             node: pipeCallExpression.callee,
+            messageId,
           })
           return
         }

--- a/src/rules/effects/no-effect-decorator.ts
+++ b/src/rules/effects/no-effect-decorator.ts
@@ -6,8 +6,6 @@ import {
   docsUrl,
   getDecoratorArgument,
   getImportAddFix,
-  getNearestUpperNodeFrom,
-  isClassDeclaration,
   isIdentifier,
   MODULE_PATHS,
 } from '../../utils'
@@ -20,7 +18,10 @@ export type MessageIds =
 
 type Options = []
 type EffectDecorator = TSESTree.Decorator & {
-  parent: TSESTree.ClassProperty & { value: TSESTree.CallExpression }
+  parent: TSESTree.ClassProperty & {
+    parent: TSESTree.ClassBody & { parent: TSESTree.ClassDeclaration }
+    value: TSESTree.CallExpression
+  }
 }
 
 const createEffect = 'createEffect'
@@ -95,10 +96,7 @@ function getFixes(
   sourceCode: Readonly<TSESLint.SourceCode>,
   fixer: TSESLint.RuleFixer,
 ): TSESLint.RuleFix[] {
-  const classDeclaration = getNearestUpperNodeFrom(node, isClassDeclaration)
-
-  if (!classDeclaration) return []
-
+  const classDeclaration = node.parent.parent.parent
   const {
     parent: { value: propertyValueExpression },
   } = node

--- a/src/rules/effects/prefer-concat-latest-from.ts
+++ b/src/rules/effects/prefer-concat-latest-from.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import {
   createEffectExpression,
   docsUrl,
-  getConditionalImportFix,
+  getImportAddFix,
   MODULE_PATHS,
 } from '../../utils'
 
@@ -45,15 +45,14 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
             {
               messageId: messageIdSuggest,
               fix: (fixer) => {
-                return [
-                  fixer.replaceText(node, 'concatLatestFrom'),
-                  ...getConditionalImportFix(
+                return [fixer.replaceText(node, 'concatLatestFrom')].concat(
+                  getImportAddFix({
                     fixer,
+                    importedName: 'concatLatestFrom',
+                    moduleName: MODULE_PATHS.effects,
                     node,
-                    'concatLatestFrom',
-                    MODULE_PATHS.effects,
-                  ),
-                ]
+                  }),
+                )
               },
             },
           ],

--- a/src/rules/effects/prefer-concat-latest-from.ts
+++ b/src/rules/effects/prefer-concat-latest-from.ts
@@ -39,8 +39,8 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
         node: TSESTree.Identifier,
       ) {
         context.report({
-          messageId,
           node,
+          messageId,
           suggest: [
             {
               messageId: messageIdSuggest,

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -1,7 +1,7 @@
 export const effectCreator = `ClassProperty[value.callee.name='createEffect']`
 
 export const effectDecorator = `Decorator[expression.callee.name='Effect']`
-export const classPropertyWithEffectDecorator = `ClassProperty > ${effectDecorator}`
+export const classPropertyWithEffectDecorator = `ClassDeclaration > ClassBody > ClassProperty > ${effectDecorator}`
 
 export const actionCreator = `CallExpression[callee.name='createAction']`
 export const actionCreatorWithLiteral = `${actionCreator}[arguments.0.type='Literal']`

--- a/tests/rules/avoid-cyclic-effects.test.ts
+++ b/tests/rules/avoid-cyclic-effects.test.ts
@@ -5,12 +5,14 @@ import rule, { messageId } from '../../src/rules/effects/avoid-cyclic-effects'
 import { ruleTester } from '../utils'
 
 const setup = `
-  import { Actions, createEffect, ofType } from '@ngrx/effects';
-  import { createAction } from '@ngrx/store';
+  import type { OnRunEffects } from '@ngrx/effects'
+  import { EffectConfig } from '@ngrx/effects'
+  import { Actions, createEffect, ofType } from '@ngrx/effects'
+  import { createAction } from '@ngrx/store'
   import { map, tap } from 'rxjs/operators'
 
-  const foo = createAction('FOO');
-  const bar = createAction('BAR');
+  const foo = createAction('FOO')
+  const bar = createAction('BAR')
 
   const fromFoo = {
     foo,

--- a/tests/rules/no-effect-decorator.test.ts
+++ b/tests/rules/no-effect-decorator.test.ts
@@ -10,7 +10,7 @@ import { ruleTester } from '../utils'
 
 ruleTester().run(path.parse(__filename).name, rule, {
   valid: [
-    stripIndents`
+    `
       @Injectable()
       export class FixtureEffects {
 
@@ -81,7 +81,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     fromFixture(
       stripIndents`
-      import { createEffect, Effect } from '@ngrx/effects';
+      import { createEffect, Effect } from '@ngrx/effects'
       @Injectable()
       export class FixtureEffects {
         @Effect({ dispatch: false })
@@ -95,7 +95,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
       }`,
       {
         output: stripIndents`
-        import { createEffect, Effect } from '@ngrx/effects';
+        import { createEffect, Effect } from '@ngrx/effects'
         @Injectable()
         export class FixtureEffects {
 
@@ -110,8 +110,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     fromFixture(
       stripIndents`
-      import { Injectable } from '@angular/core';
-      import { Effect } from '@ngrx/effects';
+      import { Injectable } from '@angular/core'
+      import { Effect } from '@ngrx/effects'
       @Injectable()
       export class FixtureEffects {
         @Effect(config)
@@ -125,8 +125,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
       }`,
       {
         output: stripIndents`
-        import { Injectable } from '@angular/core';
-        import { Effect, createEffect } from '@ngrx/effects';
+        import { Injectable } from '@angular/core'
+        import { Effect, createEffect } from '@ngrx/effects'
         @Injectable()
         export class FixtureEffects {
 
@@ -141,8 +141,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     {
       code: stripIndents`
-      import { Injectable } from '@angular/core';
-      import { Effect } from '@ngrx/effects';
+      import { Injectable } from '@angular/core'
+      import type { OnRunEffects } from '@ngrx/effects'
       @Injectable()
       export class FixtureEffects {
         @Effect(config)
@@ -160,8 +160,9 @@ ruleTester().run(path.parse(__filename).name, rule, {
         constructor(private actions: Actions) {}
       }`,
       output: stripIndents`
-      import { Injectable } from '@angular/core';
-      import { Effect, createEffect } from '@ngrx/effects';
+      import { createEffect } from '@ngrx/effects';
+      import { Injectable } from '@angular/core'
+      import type { OnRunEffects } from '@ngrx/effects'
       @Injectable()
       export class FixtureEffects {
 
@@ -189,8 +190,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
             {
               messageId: noEffectDecoratorSuggest as MessageIds,
               output: stripIndents`
-              import { Injectable } from '@angular/core';
-              import { Effect } from '@ngrx/effects';
+              import { Injectable } from '@angular/core'
+              import type { OnRunEffects } from '@ngrx/effects'
               @Injectable()
               export class FixtureEffects {
                 @Effect(config)

--- a/tests/rules/prefer-concat-latest-from.test.ts
+++ b/tests/rules/prefer-concat-latest-from.test.ts
@@ -1,5 +1,4 @@
-import { stripIndent, stripIndents } from 'common-tags'
-import { fromFixture } from 'eslint-etc'
+import { stripIndent } from 'common-tags'
 import path from 'path'
 import type { MessageIds } from '../../src/rules/effects/prefer-concat-latest-from'
 import rule, {
@@ -10,7 +9,7 @@ import { ruleTester } from '../utils'
 
 ruleTester().run(path.parse(__filename).name, rule, {
   valid: [
-    stripIndents`
+    `
       export class Effect {
         effect$ = createEffect(
           () =>
@@ -23,7 +22,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
             ),
         );
       }`,
-    stripIndents`
+    `
       class Effect {
         detail$ = createEffect(() => {
           return this.actions.pipe(
@@ -35,30 +34,11 @@ ruleTester().run(path.parse(__filename).name, rule, {
             })
           )
         })
-      }
-    `,
+      }`,
   ],
   invalid: [
-    fromFixture(
-      stripIndent`
-        export class Effect {
-          effect$ = createEffect(
-            () =>
-              this.actions$.pipe(
-                ofType(CollectionApiActions.addBookSuccess),
-                withLatestFrom(action => this.store.select(fromBooks.getCollectionBookIds)),
-                ~~~~~~~~~~~~~~ [${messageId}]
-                switchMap(([action, bookCollection]) => {
-                  return {}
-                })
-              ),
-          );
-        }
-      `,
-    ),
     {
-      code: stripIndents`
-        import { createEffect } from '@ngrx/effects';
+      code: stripIndent`
         export class Effect {
           effect$ = createEffect(
             () =>
@@ -67,7 +47,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
                 withLatestFrom(action => this.store.select(fromBooks.getCollectionBookIds)),
                 switchMap(([action, bookCollection]) => {
                   return {}
-                })
+                }),
               ),
           );
         }`,
@@ -77,8 +57,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
           suggestions: [
             {
               messageId: messageIdSuggest as MessageIds,
-              output: stripIndents`
-              import { createEffect, concatLatestFrom } from '@ngrx/effects';
+              output: stripIndent`
+              import { concatLatestFrom } from '@ngrx/effects';
               export class Effect {
                 effect$ = createEffect(
                   () =>
@@ -87,7 +67,48 @@ ruleTester().run(path.parse(__filename).name, rule, {
                       concatLatestFrom(action => this.store.select(fromBooks.getCollectionBookIds)),
                       switchMap(([action, bookCollection]) => {
                         return {}
-                      })
+                      }),
+                    ),
+                );
+              }`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        import type { OnRunEffects } from '@ngrx/effects'
+        export class Effect {
+          effect$ = createEffect(
+            () =>
+              this.actions$.pipe(
+                ofType(CollectionApiActions.addBookSuccess),
+                withLatestFrom(action => this.store.select(fromBooks.getCollectionBookIds)),
+                switchMap(([action, bookCollection]) => {
+                  return {}
+                }),
+              ),
+          );
+        }`,
+      errors: [
+        {
+          messageId: messageId,
+          suggestions: [
+            {
+              messageId: messageIdSuggest as MessageIds,
+              output: stripIndent`
+              import { concatLatestFrom } from '@ngrx/effects';
+              import type { OnRunEffects } from '@ngrx/effects'
+              export class Effect {
+                effect$ = createEffect(
+                  () =>
+                    this.actions$.pipe(
+                      ofType(CollectionApiActions.addBookSuccess),
+                      concatLatestFrom(action => this.store.select(fromBooks.getCollectionBookIds)),
+                      switchMap(([action, bookCollection]) => {
+                        return {}
+                      }),
                     ),
                 );
               }`,

--- a/tests/rules/updater-explicit-return-type.test.ts
+++ b/tests/rules/updater-explicit-return-type.test.ts
@@ -7,7 +7,9 @@ import rule, {
 import { ruleTester } from '../utils'
 
 const setup = stripIndent`
-  import { ComponentStore } from "@ngrx/component-store";
+  import type { SelectConfig } from '@ngrx/component-store'
+  import { Projector } from '@ngrx/component-store'
+  import { ComponentStore } from '@ngrx/component-store'
 
   interface Movie {
     readonly genre: string;

--- a/tests/rules/use-effects-lifecycle-interface.test.ts
+++ b/tests/rules/use-effects-lifecycle-interface.test.ts
@@ -14,7 +14,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
     `
       class UserEffects implements OnInitEffects {
         ngrxOnInitEffects(): Action {
-          return { type: '[UserEffects]: Init' };
+          return { type: '[UserEffects]: Init' }
         }
       }
     `,
@@ -25,10 +25,10 @@ ruleTester().run(path.parse(__filename).name, rule, {
             this.actions$.pipe(
               ofType('UPDATE_USER'),
               tap(action => {
-                console.log(action);
+                console.log(action)
               })
             ),
-          { dispatch: false });
+          { dispatch: false })
         ngrxOnRunEffects(resolvedEffects$: Observable<EffectNotification>) {
           return this.actions$.pipe(
             ofType('LOGGED_IN'),
@@ -37,7 +37,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
                 takeUntil(this.actions$.pipe(ofType('LOGGED_OUT')))
               )
             )
-          );
+          )
         }
       }
     `,
@@ -45,17 +45,17 @@ ruleTester().run(path.parse(__filename).name, rule, {
       class EffectWithIdentifier implements OnIdentifyEffects {
         constructor(private effectIdentifier: string) {}
         ngrxOnIdentifyEffects() {
-          return this.effectIdentifier;
+          return this.effectIdentifier
         }
       }
     `,
     `
-      class UserEffects implements OnInitEffects, OnIdentifyEffects {
+      class UserEffects implements ngrx.OnInitEffects, OnIdentifyEffects {
         ngrxOnInitEffects(): Action {
-          return { type: '[UserEffects]: Init' };
+          return { type: '[UserEffects]: Init' }
         }
         ngrxOnIdentifyEffects(): string {
-          return '';
+          return ''
         }
       }
     `,
@@ -79,6 +79,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     fromFixture(
       stripIndent`
+        import Effects from '@ngrx/effects'
         class UserEffects {
           ngrxOnIdentifyEffects() {}
           ~~~~~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
@@ -86,7 +87,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
       `,
       {
         output: stripIndent`
-          import { OnIdentifyEffects } from '@ngrx/effects';
+          import Effects, { OnIdentifyEffects } from '@ngrx/effects'
           class UserEffects implements OnIdentifyEffects {
             ngrxOnIdentifyEffects() {}
           }
@@ -113,7 +114,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     fromFixture(
       stripIndent`
-        import { OnInitEffects } from '@ngrx/effects';
+        import * as ngrx from '@ngrx/effects'
         class UserEffects {
           ngrxOnInitEffects() {}
           ~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
@@ -122,6 +123,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
       {
         output: stripIndent`
           import { OnInitEffects } from '@ngrx/effects';
+          import * as ngrx from '@ngrx/effects'
           class UserEffects implements OnInitEffects {
             ngrxOnInitEffects() {}
           }
@@ -130,7 +132,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     fromFixture(
       stripIndent`
-        import { OnInitEffects, OnRunEffects } from '@ngrx/effects';
+        import type { OnInitEffects, OnRunEffects } from '@ngrx/effects'
         class UserEffects implements OnInitEffects, OnRunEffects {
           ngrxOnInitEffects() {}
 
@@ -142,7 +144,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
       `,
       {
         output: stripIndent`
-          import { OnInitEffects, OnRunEffects, OnIdentifyEffects } from '@ngrx/effects';
+          import type { OnInitEffects, OnRunEffects, OnIdentifyEffects } from '@ngrx/effects'
           class UserEffects implements OnInitEffects, OnRunEffects, OnIdentifyEffects {
             ngrxOnInitEffects() {}
 

--- a/tests/rules/use-selector-in-select.test.ts
+++ b/tests/rules/use-selector-in-select.test.ts
@@ -48,6 +48,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
   invalid: [
     fromFixture(
       stripIndent`
+        import type { Selector } from '@ngrx/store'
+        import { MemoizeFn } from '@ngrx/store'
         import { Store } from '@ngrx/store'
         export class Component {
           view$ = this.store.pipe(select('customers'))


### PR DESCRIPTION
Currently, the `utils/findBy*` isn't able to handle multiple imports... so when I have something like this:

```ts
import type { Something } from '@ngrx/store'
import { Store } from '@ngrx/store'
```

...the `findNgRxStoreName` returns null as it stops at the first `ImportDeclaration`.

By the way, it was a real situation in an application I was working on, some rules weren't behaving correctly as the imports, like here, are split between type-only and conventional imports 😅 

I've added a test for one rule of each package, LMK if it's sufficient :)