### PR TITLE
fix(avoid-duplicate-actions-in-reducer): simplify

### DIFF
--- a/scripts/generate-config.ts
+++ b/scripts/generate-config.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from 'fs'
 import { join } from 'path'
 import { format, resolveConfig } from 'prettier'
 import { rules } from '../src/rules'
-import { RuleModule } from '../src/utils/types'
+import type { RuleModule } from '../src/utils/types'
 
 const prettierConfig = resolveConfig.sync(__dirname)
 

--- a/src/rules/store/avoid-duplicate-actions-in-reducer.ts
+++ b/src/rules/store/avoid-duplicate-actions-in-reducer.ts
@@ -35,7 +35,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
         collectedActions.set(action.name, [...actions, action])
       },
       [`${createReducer}:exit`]() {
-        for (const [action, identifiers] of collectedActions) {
+        for (const [actionName, identifiers] of collectedActions) {
           if (identifiers.length <= 1) {
             break
           }
@@ -45,7 +45,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
               node,
               messageId,
               data: {
-                actionName: action,
+                actionName,
               },
             })
           }

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -40,7 +40,10 @@ export const pipeableSelect = (storeName: string) =>
 export const storeSelect = (storeName: string) =>
   `${storeExpression(storeName)}[callee.property.name='select']`
 
-export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'] CallExpression[callee.name='on'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`
+export const createReducer = `CallExpression[callee.name='createReducer']`
+
+export const onFunctionWithoutType =
+  `${createReducer} CallExpression[callee.name='on'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))` as const
 
 export const storeActionReducerMap = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='StoreModule'][callee.property.name=/forRoot|forFeature/] > ObjectExpression:first-child > Property`
 

--- a/tests/rules/avoid-duplicate-actions-in-reducer.test.ts
+++ b/tests/rules/avoid-duplicate-actions-in-reducer.test.ts
@@ -15,6 +15,20 @@ ruleTester().run(path.parse(__filename).name, rule, {
       on(def, state => state),
       on(ghi, state => state),
     )`,
+    `
+    export const reducer = createReducer(
+      {},
+      on(abc, state => state),
+      on(def, state => state),
+      on(ghi, state => state),
+    )
+
+    export const reducerTwo = createReducer(
+      {},
+      on(abc, state => state),
+      on(def, state => state),
+      on(ghi, state => state),
+    )`,
     // does not crash when no arguments present
     `
     export const reducer = createReducer(


### PR DESCRIPTION
Currently it's checking/reporting duplication on every `createReducer > Identifier`). With the new implementation we collect all the possible duplicate nodes and report it on the `createReducer:exit` as mentioned in #180.

This unintentionally also fixes a possible false positive that is having different reducers controlling actions with the same names :stuck_out_tongue: