### PR TITLE
refactor: use `as const` for selectors

### DIFF
--- a/src/rules/component-store/updater-explicit-return-type.ts
+++ b/src/rules/component-store/updater-explicit-return-type.ts
@@ -26,11 +26,10 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     const storeName = findNgRxComponentStoreName(context)
-
     const selectors = [
-      `ClassProperty > CallExpression[callee.object.type="ThisExpression"][callee.property.name='updater'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`,
+      `ClassProperty > CallExpression[callee.object.type='ThisExpression'][callee.property.name='updater'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`,
       storeName
-        ? `ClassProperty > CallExpression[callee.object.object.type="ThisExpression"][callee.object.property.name='${storeName}'][callee.property.name='updater'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`
+        ? `ClassProperty > CallExpression[callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'][callee.property.name='updater'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`
         : '',
     ]
       .filter(Boolean)

--- a/src/rules/effects/avoid-cyclic-effects.ts
+++ b/src/rules/effects/avoid-cyclic-effects.ts
@@ -120,7 +120,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     }
 
     return {
-      [`${createEffectExpression}:not([arguments.1]:has(Property[key.name="dispatch"][value.value=false])) CallExpression[callee.property.name='pipe'][callee.object.property.name="${actionsName}"]`]:
+      [`${createEffectExpression}:not([arguments.1]:has(Property[key.name='dispatch'][value.value=false])) CallExpression[callee.property.name='pipe'][callee.object.property.name='${actionsName}']`]:
         checkNode,
     }
   },

--- a/src/rules/store/avoid-combining-selectors.ts
+++ b/src/rules/store/avoid-combining-selectors.ts
@@ -38,7 +38,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       storeName,
     )}[callee.property.name='pipe']:has(CallExpression[callee.name='select']), ${storeSelect(
       storeName,
-    )})`
+    )})` as const
 
     return {
       [`CallExpression[callee.name='combineLatest'][arguments.length>1] ${pipeableOrStoreSelect} ~ ${pipeableOrStoreSelect}`](

--- a/src/rules/store/avoid-mapping-selectors.ts
+++ b/src/rules/store/avoid-mapping-selectors.ts
@@ -36,10 +36,10 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
 
     const pipeWithSelectAndMapSelector = `${storePipe(
       storeName,
-    )}:has(CallExpression[callee.name='select'] ~ CallExpression[callee.name='map'])`
+    )}:has(CallExpression[callee.name='select'] ~ CallExpression[callee.name='map'])` as const
     const selectSelector = `${storeExpressionCallable(
       storeName,
-    )}[callee.object.callee.property.name='select']`
+    )}[callee.object.callee.property.name='select']` as const
 
     return {
       [`:matches(${selectSelector}, ${pipeWithSelectAndMapSelector}) > CallExpression[callee.name='map']`](

--- a/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
+++ b/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
@@ -34,7 +34,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      [`CallExpression[callee.name="createFeatureSelector"] TSTypeParameterInstantiation[params.length>1]`](
+      [`CallExpression[callee.name='createFeatureSelector'] TSTypeParameterInstantiation[params.length>1]`](
         node: TSESTree.TSTypeParameterInstantiation,
       ) {
         context.report({

--- a/src/rules/store/prefix-selectors-with-select.ts
+++ b/src/rules/store/prefix-selectors-with-select.ts
@@ -26,7 +26,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      'VariableDeclarator[id.name!=/^select[A-Z][a-zA-Z]+$/]:matches(:has(TSTypeAnnotation[typeAnnotation.typeName.name=/^MemoizedSelector(WithProps$|$)/]), :has(CallExpression[callee.name=/^(createSelector|createFeatureSelector)$/]))'({
+      'VariableDeclarator[id.name!=/^select[A-Z][a-zA-Z]+$/]:matches(:has(TSTypeAnnotation[typeAnnotation.typeName.name=/^MemoizedSelector(WithProps$|$)/]), :has(CallExpression[callee.name=/^create(Feature)?Selector$/]))'({
         id,
       }: TSESTree.VariableDeclarator) {
         context.report({ node: id, messageId })

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -1,12 +1,15 @@
 export const effectCreator = `ClassProperty[value.callee.name='createEffect']`
 
 export const effectDecorator = `Decorator[expression.callee.name='Effect']`
-export const classPropertyWithEffectDecorator = `ClassDeclaration > ClassBody > ClassProperty > ${effectDecorator}`
+export const classPropertyWithEffectDecorator =
+  `ClassDeclaration > ClassBody > ClassProperty > ${effectDecorator}` as const
 
 export const actionCreator = `CallExpression[callee.name='createAction']`
-export const actionCreatorWithLiteral = `${actionCreator}[arguments.0.type='Literal']`
-export const actionCreatorProps = `${actionCreator} CallExpression`
-export const actionCreatorPropsComputed = `${actionCreatorProps} > TSTypeParameterInstantiation > :matches(TSTypeReference[typeName.name!='Readonly'], [type=/^TS(.*)(Keyword|Type)$/])`
+export const actionCreatorWithLiteral =
+  `${actionCreator}[arguments.0.type='Literal']` as const
+export const actionCreatorProps = `${actionCreator} CallExpression` as const
+export const actionCreatorPropsComputed =
+  `${actionCreatorProps} > TSTypeParameterInstantiation > :matches(TSTypeReference[typeName.name!='Readonly'], [type=/^TS(.*)(Keyword|Type)$/])` as const
 
 export const constructorExit = `MethodDefinition[kind='constructor']:exit`
 
@@ -18,9 +21,11 @@ export const typedStore = `MethodDefinition[kind='constructor'] Identifier>TSTyp
 
 export const ngModuleDecorator = `ClassDeclaration > Decorator > CallExpression[callee.name='NgModule']`
 
-export const ngModuleProviders = `${ngModuleDecorator} ObjectExpression Property[key.name='providers'] > ArrayExpression Identifier`
+export const ngModuleProviders =
+  `${ngModuleDecorator} ObjectExpression Property[key.name='providers'] > ArrayExpression Identifier` as const
 
-export const ngModuleImports = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='EffectsModule'][callee.property.name=/forRoot|forFeature/] ArrayExpression > Identifier`
+export const ngModuleImports =
+  `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='EffectsModule'][callee.property.name=/forRoot|forFeature/] ArrayExpression > Identifier` as const
 
 export const actionDispatch = (storeName: string) =>
   `ExpressionStatement > CallExpression:matches([callee.object.name='${storeName}'][callee.property.name='dispatch'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'][callee.property.name='dispatch'])`
@@ -42,7 +47,8 @@ export const storeSelect = (storeName: string) =>
 
 export const onFunctionWithoutType = `CallExpression[callee.name='createReducer'] CallExpression[callee.name='on'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))`
 
-export const storeActionReducerMap = `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='StoreModule'][callee.property.name=/forRoot|forFeature/] > ObjectExpression:first-child > Property`
+export const storeActionReducerMap =
+  `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='StoreModule'][callee.property.name=/forRoot|forFeature/] > ObjectExpression:first-child > Property` as const
 
 export const actionReducerMap = `VariableDeclarator[id.typeAnnotation.typeAnnotation.typeName.name='ActionReducerMap'] > ObjectExpression > Property`
 
@@ -50,11 +56,16 @@ export const createEffectExpression = `ClassProperty > CallExpression[callee.nam
 
 const mapOperators = '(concat|exhaust|flat|merge|switch)Map'
 const mapToOperators = '(concat|merge|switch)MapTo'
-const mapOperatorsExpression = `${createEffectExpression} CallExpression[callee.name=/^${mapOperators}$/]`
-const mapToOperatorsExpression = `${createEffectExpression} CallExpression[callee.name=/^${mapToOperators}$/]`
+const mapOperatorsExpression =
+  `${createEffectExpression} CallExpression[callee.name=/^${mapOperators}$/]` as const
+const mapToOperatorsExpression =
+  `${createEffectExpression} CallExpression[callee.name=/^${mapToOperators}$/]` as const
 
-export const createEffectBody = `${createEffectExpression} > ArrowFunctionExpression`
+export const createEffectBody =
+  `${createEffectExpression} > ArrowFunctionExpression` as const
 
-export const effectsImplicitReturn = `${mapOperatorsExpression} > ArrowFunctionExpression > ArrayExpression, ${mapToOperatorsExpression} ArrayExpression`
+export const effectsImplicitReturn =
+  `${mapOperatorsExpression} > ArrowFunctionExpression > ArrayExpression, ${mapToOperatorsExpression} ArrayExpression` as const
 
-export const effectsReturn = `${mapOperatorsExpression} ReturnStatement`
+export const effectsReturn =
+  `${mapOperatorsExpression} ReturnStatement` as const


### PR DESCRIPTION
**Before**:

<img width="513" alt="Captura de Tela 2021-09-04 às 02 19 23" src="https://user-images.githubusercontent.com/11965907/132083490-369ad1b8-c6c6-4ed8-a426-26997db4d169.png">

**After**:

<img width="653" alt="Captura de Tela 2021-09-04 às 02 19 45" src="https://user-images.githubusercontent.com/11965907/132083500-656f85b9-f6bd-4216-a29c-9a551ee91d9b.png">

IMHO, it's much nicer to see what is the content of the select by just hovering it, instead of going to that file.