### PR TITLE
fix: handle literals properly

### DIFF
--- a/src/rules/effects/no-effects-in-providers.ts
+++ b/src/rules/effects/no-effects-in-providers.ts
@@ -3,9 +3,9 @@ import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
 import {
   docsUrl,
+  effectsInNgModuleImports,
+  effectsInNgModuleProviders,
   ngModuleDecorator,
-  ngModuleImports,
-  ngModuleProviders,
 } from '../../utils'
 
 export const messageId = 'noEffectsInProviders'
@@ -35,21 +35,21 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     const importedEffectsNames: string[] = []
 
     return {
-      [ngModuleProviders](node: TSESTree.Identifier) {
+      [effectsInNgModuleProviders](node: TSESTree.Identifier) {
         effectsInProviders.push(node)
       },
-      [ngModuleImports](node: TSESTree.Identifier) {
+      [effectsInNgModuleImports](node: TSESTree.Identifier) {
         importedEffectsNames.push(node.name)
       },
       [`${ngModuleDecorator}:exit`]() {
-        effectsInProviders.forEach((effect: TSESTree.Identifier) => {
-          if (importedEffectsNames.includes(effect.name)) {
+        for (const effectInProvider of effectsInProviders) {
+          if (importedEffectsNames.includes(effectInProvider.name)) {
             context.report({
-              node: effect,
+              node: effectInProvider,
               messageId,
             })
           }
-        })
+        }
       },
     }
   },

--- a/src/rules/store/no-reducer-in-key-names.ts
+++ b/src/rules/store/no-reducer-in-key-names.ts
@@ -4,8 +4,7 @@ import path from 'path'
 import {
   actionReducerMap,
   docsUrl,
-  isIdentifier,
-  isLiteral,
+  metadataProperty,
   storeActionReducerMap,
 } from '../../utils'
 
@@ -31,26 +30,14 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   },
   defaultOptions: [],
   create: (context) => {
-    const excludedKeyword = 'reducer'
-
-    function hasKeyword(name: string): boolean {
-      return name.toLowerCase().includes(excludedKeyword)
-    }
-
     return {
-      [`${storeActionReducerMap}, ${actionReducerMap}`](
-        node: TSESTree.Property,
-      ) {
-        const key = node.key
-        if (
-          (isLiteral(key) && hasKeyword(key.raw)) ||
-          (isIdentifier(key) && hasKeyword(key.name))
-        ) {
-          context.report({
-            node: key,
-            messageId,
-          })
-        }
+      [`:matches(${storeActionReducerMap}, ${actionReducerMap}) > :matches(Property[key.type='Identifier'][key.name=/reducer$/i], ${metadataProperty(
+        /reducer$/i,
+      )})`]({ key }: TSESTree.Property) {
+        context.report({
+          node: key,
+          messageId,
+        })
       },
     }
   },

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -14,36 +14,54 @@ export const actionCreatorPropsComputed =
 export const constructorExit = `MethodDefinition[kind='constructor']:exit`
 
 export const dispatchInEffects = (storeName: string) =>
-  `ClassProperty > CallExpression:has(Identifier[name='createEffect']) CallExpression > MemberExpression:has(Identifier[name='dispatch']):has(MemberExpression > Identifier[name='${storeName}'])`
+  `ClassProperty > CallExpression:has(Identifier[name='createEffect']) CallExpression > MemberExpression:has(Identifier[name='dispatch']):has(MemberExpression > Identifier[name='${storeName}'])` as const
 
 export const injectedStore = `MethodDefinition[kind='constructor'] Identifier[typeAnnotation.typeAnnotation.typeName.name='Store']`
 export const typedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name='Store'][typeParameters.params]`
 
 export const ngModuleDecorator = `ClassDeclaration > Decorator > CallExpression[callee.name='NgModule']`
 
-export const ngModuleProviders =
-  `${ngModuleDecorator} ObjectExpression Property[key.name='providers'] > ArrayExpression Identifier` as const
-
 export const ngModuleImports =
-  `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='EffectsModule'][callee.property.name=/forRoot|forFeature/] ArrayExpression > Identifier` as const
+  `${ngModuleDecorator} ObjectExpression ${metadataProperty(
+    'imports',
+  )} > ArrayExpression` as const
+
+export const ngModuleProviders =
+  `${ngModuleDecorator} ObjectExpression ${metadataProperty(
+    'providers',
+  )} > ArrayExpression` as const
+
+export const effectsInNgModuleImports =
+  `${ngModuleImports} CallExpression[callee.object.name='EffectsModule'][callee.property.name=/^for(Root|Feature)$/] ArrayExpression > Identifier` as const
+
+export const effectsInNgModuleProviders =
+  `${ngModuleProviders} Identifier` as const
+
+export function metadataProperty(key: RegExp): string
+export function metadataProperty<TKey extends string>(
+  key: TKey,
+): `Property:matches([key.name=${TKey}][computed=false], [key.value=${TKey}], [key.quasis.0.value.raw=${TKey}])`
+export function metadataProperty(key: RegExp | string): string {
+  return `Property:matches([key.name=${key}][computed=false], [key.value=${key}], [key.quasis.0.value.raw=${key}])`
+}
 
 export const actionDispatch = (storeName: string) =>
-  `ExpressionStatement > CallExpression:matches([callee.object.name='${storeName}'][callee.property.name='dispatch'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'][callee.property.name='dispatch'])`
+  `ExpressionStatement > CallExpression:matches([callee.object.name='${storeName}'][callee.property.name='dispatch'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'][callee.property.name='dispatch'])` as const
 
 export const storeExpression = (storeName: string) =>
-  `CallExpression:matches([callee.object.name='${storeName}'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'])`
+  `CallExpression:matches([callee.object.name='${storeName}'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'])` as const
 
 export const storeExpressionCallable = (storeName: string) =>
-  `CallExpression:matches([callee.object.callee.object.name='${storeName}'], [callee.object.callee.object.object.type='ThisExpression'][callee.object.callee.object.property.name='${storeName}'])`
+  `CallExpression:matches([callee.object.callee.object.name='${storeName}'], [callee.object.callee.object.object.type='ThisExpression'][callee.object.callee.object.property.name='${storeName}'])` as const
 
 export const storePipe = (storeName: string) =>
-  `${storeExpression(storeName)}[callee.property.name='pipe']`
+  `${storeExpression(storeName)}[callee.property.name='pipe']` as const
 
 export const pipeableSelect = (storeName: string) =>
-  `${storePipe(storeName)} CallExpression[callee.name='select']`
+  `${storePipe(storeName)} CallExpression[callee.name='select']` as const
 
 export const storeSelect = (storeName: string) =>
-  `${storeExpression(storeName)}[callee.property.name='select']`
+  `${storeExpression(storeName)}[callee.property.name='select']` as const
 
 export const createReducer = `CallExpression[callee.name='createReducer']`
 
@@ -51,9 +69,9 @@ export const onFunctionWithoutType =
   `${createReducer} CallExpression[callee.name='on'] > ArrowFunctionExpression:not([returnType.typeAnnotation],:has(CallExpression))` as const
 
 export const storeActionReducerMap =
-  `${ngModuleDecorator} ObjectExpression Property[key.name='imports'] > ArrayExpression CallExpression[callee.object.name='StoreModule'][callee.property.name=/forRoot|forFeature/] > ObjectExpression:first-child > Property` as const
+  `${ngModuleImports} CallExpression[callee.object.name='StoreModule'][callee.property.name=/^for(Root|Feature)$/] > ObjectExpression:first-child` as const
 
-export const actionReducerMap = `VariableDeclarator[id.typeAnnotation.typeAnnotation.typeName.name='ActionReducerMap'] > ObjectExpression > Property`
+export const actionReducerMap = `VariableDeclarator[id.typeAnnotation.typeAnnotation.typeName.name='ActionReducerMap'] > ObjectExpression`
 
 export const createEffectExpression = `ClassProperty > CallExpression[callee.name='createEffect']`
 

--- a/tests/rules/no-effects-in-providers.test.ts
+++ b/tests/rules/no-effects-in-providers.test.ts
@@ -29,21 +29,31 @@ ruleTester().run(path.parse(__filename).name, rule, {
           EffectsModule.forFeature([FeatEffectOne, FeatEffectTwo]),
           EffectsModule.forFeature([FeatEffectThree]),
         ],
-        providers: [FeatEffectTwo, UnRegisteredEffect, FeatEffectThree, RootEffectTwo],
-                    ~~~~~~~~~~~~~                                                       [${messageId}]
-                                                       ~~~~~~~~~~~~~~~                  [${messageId}]
-                                                                        ~~~~~~~~~~~~~   [${messageId}]
+        'providers': [
+          FeatEffectTwo,
+          ~~~~~~~~~~~~~   [${messageId}]
+          UnRegisteredEffect,
+          FeatEffectThree,
+          ~~~~~~~~~~~~~~~ [${messageId}]
+          RootEffectTwo
+          ~~~~~~~~~~~~~   [${messageId}]
+        ],
       })
       export class AppModule {}`,
     ),
     fromFixture(
       stripIndent`
       @NgModule({
-        providers: [FeatEffectTwo, UnRegisteredEffect, FeatEffectThree, RootEffectTwo],
-                    ~~~~~~~~~~~~~                                                       [${messageId}]
-                                                       ~~~~~~~~~~~~~~~                  [${messageId}]
-                                                                        ~~~~~~~~~~~~~   [${messageId}]
-        imports: [
+        [\`providers\`]: [
+          FeatEffectTwo,
+          ~~~~~~~~~~~~~   [${messageId}]
+          UnRegisteredEffect,
+          FeatEffectThree,
+          ~~~~~~~~~~~~~~~ [${messageId}]
+          RootEffectTwo
+          ~~~~~~~~~~~~~   [${messageId}]
+        ],
+        ['imports']: [
           StoreModule.forFeature('persons', {"foo": "bar"}),
           EffectsModule.forRoot([RootEffectOne, RootEffectTwo]),
           EffectsModule.forFeature([FeatEffectOne, FeatEffectTwo]),

--- a/tests/rules/no-reducer-in-key-names.test.ts
+++ b/tests/rules/no-reducer-in-key-names.test.ts
@@ -73,8 +73,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
               ~~~~~~~~~~                        [${messageId}]
               'fooReducer': foo,
               ~~~~~~~~~~~~                      [${messageId}]
-              FoeReducer: FoeReducer,
-              ~~~~~~~~~~                        [${messageId}]
+              ['FoeReducer']: FoeReducer,
+               ~~~~~~~~~~~~                     [${messageId}]
             }),
           ],
         })
@@ -89,8 +89,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
           ~~~~~~~~~~                          [${messageId}]
           'fooReducer': foo,
           ~~~~~~~~~~~~                        [${messageId}]
-          FoeReducer: fromFoe.reducer,
-          ~~~~~~~~~~                          [${messageId}]
+          [\`FoeReducer\`]: fromFoe.reducer,
+           ~~~~~~~~~~~~                       [${messageId}]
         };`,
     ),
   ],


### PR DESCRIPTION
Currently the rules `no-effects-in-providers` and `no-reducer-in-key-names` aren't capable of looking at `@NgModule` metadata if it's a computed literal or a template literal.