### PR TITLE
feat(prefix-selectors-with-select): add support for `createSelectorFactory`

### DIFF
--- a/docs/rules/prefix-selectors-with-select.md
+++ b/docs/rules/prefix-selectors-with-select.md
@@ -39,7 +39,9 @@ Examples of **correct** code for this rule:
 export const selectFeature = createSelector((state: AppState) => state.feature)
 export const selectFeature: MemoizedSelector<any, any> = (state: AppState) =>
   state.feature
+
 const selectFeature = createFeatureSelector<FeatureState>(featureKey)
+
 export const selectThing = (id: string) =>
   createSelector(selectThings, (things) => things[id])
 ```

--- a/docs/rules/prefix-selectors-with-select.md
+++ b/docs/rules/prefix-selectors-with-select.md
@@ -37,6 +37,7 @@ Examples of **correct** code for this rule:
 
 ```ts
 export const selectFeature = createSelector((state: AppState) => state.feature)
+
 export const selectFeature: MemoizedSelector<any, any> = (state: AppState) =>
   state.feature
 

--- a/docs/rules/prefix-selectors-with-select.md
+++ b/docs/rules/prefix-selectors-with-select.md
@@ -13,7 +13,8 @@ Examples of **incorrect** code for this rule:
 export const feature = createSelector((state: AppState) => state.feature)
 
 // ⚠ Usage of a selector without any description
-export const select = createSelector((state: AppState) => state.feature)
+export const select = (id: string) =>
+  createSelector((state: AppState) => state.feature)
 
 // ⚠ Usage of a selector with a `get` prefix
 export const getFeature: MemoizedSelector<any, any> = (state: AppState) =>
@@ -21,6 +22,15 @@ export const getFeature: MemoizedSelector<any, any> = (state: AppState) =>
 
 // ⚠ Usage of a selector with improper casing
 const selectfeature = createFeatureSelector<AppState, FeatureState>(featureKey)
+
+// ⚠ Usage of a `createSelectorFactory` without `select` prefix
+const createSelector = createSelectorFactory((projectionFun) =>
+  defaultMemoize(
+    projectionFun,
+    orderDoesNotMatterComparer,
+    orderDoesNotMatterComparer,
+  ),
+)
 ```
 
 Examples of **correct** code for this rule:
@@ -30,6 +40,8 @@ export const selectFeature = createSelector((state: AppState) => state.feature)
 export const selectFeature: MemoizedSelector<any, any> = (state: AppState) =>
   state.feature
 const selectFeature = createFeatureSelector<FeatureState>(featureKey)
+export const selectThing = (id: string) =>
+  createSelector(selectThings, (things) => things[id])
 ```
 
 ## Further reading

--- a/src/rules/store/prefix-selectors-with-select.ts
+++ b/src/rules/store/prefix-selectors-with-select.ts
@@ -26,10 +26,20 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      'VariableDeclarator[id.name!=/^select[A-Z][a-zA-Z]+$/]:matches(:has(TSTypeAnnotation[typeAnnotation.typeName.name=/^MemoizedSelector(WithProps$|$)/]), :has(CallExpression[callee.name=/^create(Feature)?Selector$/]))'({
+      'VariableDeclarator[id.name!=/^select[A-Z][a-zA-Z]+$/]:matches([id.typeAnnotation.typeAnnotation.typeName.name=/^MemoizedSelector(WithProps)?$/], :has(CallExpression[callee.name=/^(create(Feature)?Selector|createSelectorFactory)$/]))'({
         id,
       }: TSESTree.VariableDeclarator) {
-        context.report({ node: id, messageId })
+        context.report({
+          loc: {
+            ...id.loc,
+            end: {
+              ...id.loc.end,
+              column: id.typeAnnotation?.range[0] ?? id.range[1],
+            },
+          },
+          node: id,
+          messageId,
+        })
       },
     }
   },

--- a/tests/rules/prefix-selectors-with-select.test.ts
+++ b/tests/rules/prefix-selectors-with-select.test.ts
@@ -9,21 +9,25 @@ import { ruleTester } from '../utils'
 ruleTester().run(path.parse(__filename).name, rule, {
   valid: [
     `
-    export const selectFeature:MemoizedSelector<any, any> = (state: AppState) => state.feature`,
+    export const selectFeature: MemoizedSelector<any, any> = (state: AppState) => state.feature`,
+    `
+    export const selectFeature: MemoizedSelectorWithProps<any, any> = ({ feature }) => feature`,
     `
     export const selectFeature = createSelector((state: AppState) => state.feature)`,
     `
-    export const selectFeature = createFeatureSelector<FeatureState>(featureKey);`,
+    export const selectFeature = createFeatureSelector<FeatureState>(featureKey)`,
     `
-    export const selectFeature = createFeatureSelector<AppState, FeatureState>(featureKey);`,
+    export const selectFeature = createFeatureSelector<AppState, FeatureState>(featureKey)`,
     `
-    export const selectFeature = createSelector((state, props) => state.counter[props.id])`,
+    export const selectThing = (id: string) => createSelector(selectThings, things => things[id])`,
+    `
+    export const selectFeature = createSelectorFactory(factoryFn)`,
   ],
   invalid: [
     fromFixture(
       stripIndent`
-        export const getFeature: MemoizedSelector<any, any> = (state: AppState) => state.feature
-                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[${messageId}]`,
+        export const getCount: MemoizedSelector<any, any> = (state: AppState) => state.feature
+                     ~~~~~~~~                        [${messageId}]`,
     ),
     fromFixture(
       stripIndent`
@@ -32,12 +36,19 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     fromFixture(
       stripIndent`
-        export const select = createSelector((state: AppState) => state.feature)
+        export const select = (id: string) => createSelector(selectThings, things => things[id])
                      ~~~~~~                            [${messageId}]`,
     ),
     fromFixture(
       stripIndent`
-      export const feature = createFeatureSelector<AppState, FeatureState>(featureKey);
+        export const testSelect = (id: string) => {
+                     ~~~~~~~~~~                        [${messageId}]
+          return createSelector(selectThings, things => things[id])
+        }`,
+    ),
+    fromFixture(
+      stripIndent`
+      export const feature = createFeatureSelector<AppState, FeatureState>(featureKey)
                    ~~~~~~~                             [${messageId}]`,
     ),
     fromFixture(
@@ -47,8 +58,14 @@ ruleTester().run(path.parse(__filename).name, rule, {
     ),
     fromFixture(
       stripIndent`
-      const getCount = createSelector((state, props) => state * props.multiply)
-            ~~~~~~~~                                  [${messageId}]`,
+        export const createSelect = createSelectorFactory((projectionFun) =>
+                     ~~~~~~~~~~~~                     [${messageId}]
+          defaultMemoize(
+            projectionFun,
+            orderDoesNotMatterComparer,
+            orderDoesNotMatterComparer,
+          ),
+        )`,
     ),
   ],
 })


### PR DESCRIPTION
Here's the follow-up PR to handle `createSelectorFactory` as discussed in https://github.com/timdeschryver/eslint-plugin-ngrx/pull/169#discussion_r693381896.

LMK if I'm missing something in the implementation.