### PR TITLE
feat(no-reducer-in-key-names): add suggestion

### DIFF
--- a/src/rules/store/no-reducer-in-key-names.ts
+++ b/src/rules/store/no-reducer-in-key-names.ts
@@ -31,9 +31,9 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      [`:matches(${storeActionReducerMap}, ${actionReducerMap}) > :matches(Property[key.type='Identifier'][key.name=/reducer$/i], ${metadataProperty(
-        /reducer$/i,
-      )})`]({ key }: TSESTree.Property) {
+      [`:matches(${storeActionReducerMap}, ${actionReducerMap}) > ${metadataProperty(
+        /reducer/i,
+      )}`]({ key }: TSESTree.Property) {
         context.report({
           node: key,
           messageId,

--- a/src/rules/store/no-reducer-in-key-names.ts
+++ b/src/rules/store/no-reducer-in-key-names.ts
@@ -4,14 +4,20 @@ import path from 'path'
 import {
   actionReducerMap,
   docsUrl,
+  getRawText,
   metadataProperty,
   storeActionReducerMap,
 } from '../../utils'
 
-export const messageId = 'noReducerInKeyNames'
-export type MessageIds = typeof messageId
+export const noReducerInKeyNames = 'noReducerInKeyNames'
+export const noReducerInKeyNamesSuggest = 'noReducerInKeyNamesSuggest'
+export type MessageIds =
+  | typeof noReducerInKeyNames
+  | typeof noReducerInKeyNamesSuggest
 
 type Options = []
+
+const reducerKeyword = 'reducer'
 
 export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   name: path.parse(__filename).name,
@@ -19,13 +25,14 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       category: 'Best Practices',
-      description: 'Avoid the word "reducer" in the `Reducer` key names.',
+      description: `Avoid the word "${reducerKeyword}" in the key names.`,
       recommended: 'warn',
+      suggestion: true,
     },
     schema: [],
     messages: {
-      [messageId]:
-        'Avoid the word "reducer" in the key names to better represent the state.',
+      [noReducerInKeyNames]: `Avoid the word "${reducerKeyword}" in the key names to better represent the state.`,
+      [noReducerInKeyNamesSuggest]: `Remove the word "${reducerKeyword}".`,
     },
   },
   defaultOptions: [],
@@ -36,7 +43,19 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
       )}`]({ key }: TSESTree.Property) {
         context.report({
           node: key,
-          messageId,
+          messageId: noReducerInKeyNames,
+          suggest: [
+            {
+              fix: (fixer) => {
+                const keyName = getRawText(key)
+                return fixer.replaceText(
+                  key,
+                  keyName.replace(RegExp(reducerKeyword, 'i'), ''),
+                )
+              },
+              messageId: noReducerInKeyNamesSuggest,
+            },
+          ],
         })
       },
     }

--- a/src/utils/helper-functions/guards.ts
+++ b/src/utils/helper-functions/guards.ts
@@ -10,8 +10,10 @@ const isNodeOfType =
 export const isArrowFunctionExpression = isNodeOfType(
   AST_NODE_TYPES.ArrowFunctionExpression,
 )
+export const isMethodDefinition = isNodeOfType(AST_NODE_TYPES.MethodDefinition)
 export const isCallExpression = isNodeOfType(AST_NODE_TYPES.CallExpression)
 export const isClassDeclaration = isNodeOfType(AST_NODE_TYPES.ClassDeclaration)
+export const isClassProperty = isNodeOfType(AST_NODE_TYPES.ClassProperty)
 export const isExpressionStatement = isNodeOfType(
   AST_NODE_TYPES.ExpressionStatement,
 )
@@ -30,6 +32,8 @@ export const isImportNamespaceSpecifier = isNodeOfType(
 )
 export const isImportSpecifier = isNodeOfType(AST_NODE_TYPES.ImportSpecifier)
 export const isLiteral = isNodeOfType(AST_NODE_TYPES.Literal)
+export const isTemplateElement = isNodeOfType(AST_NODE_TYPES.TemplateElement)
+export const isTemplateLiteral = isNodeOfType(AST_NODE_TYPES.TemplateLiteral)
 export const isMemberExpression = isNodeOfType(AST_NODE_TYPES.MemberExpression)
 export const isProgram = isNodeOfType(AST_NODE_TYPES.Program)
 export const isTSParameterProperty = isNodeOfType(

--- a/src/utils/helper-functions/utils.ts
+++ b/src/utils/helper-functions/utils.ts
@@ -1,13 +1,19 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils'
 import {
   isCallExpression,
+  isClassProperty,
   isIdentifier,
   isIdentifierOrMemberExpression,
   isImportDeclaration,
   isImportDefaultSpecifier,
   isImportNamespaceSpecifier,
   isImportSpecifier,
+  isLiteral,
+  isMethodDefinition,
   isProgram,
+  isProperty,
+  isTemplateElement,
+  isTemplateLiteral,
   isTSTypeAnnotation,
   isTSTypeReference,
 } from './guards'
@@ -257,6 +263,30 @@ export function getDecorator(
   return decorators?.find(
     (decorator) => getDecoratorName(decorator) === decoratorName,
   )
+}
+
+export function getRawText(node: TSESTree.Node): string {
+  if (isIdentifier(node)) {
+    return node.name
+  }
+
+  if (isClassProperty(node) || isMethodDefinition(node) || isProperty(node)) {
+    return getRawText(node.key)
+  }
+
+  if (isLiteral(node)) {
+    return node.raw
+  }
+
+  if (isTemplateElement(node)) {
+    return `\`${node.value.raw}\``
+  }
+
+  if (isTemplateLiteral(node)) {
+    return `\`${node.quasis[0].value.raw}\``
+  }
+
+  throw Error(`Unexpected \`node.type\` provided: ${node.type}`)
 }
 
 function findCorrespondingNameBy(

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -16,6 +16,14 @@ export const constructorExit = `MethodDefinition[kind='constructor']:exit`
 export const dispatchInEffects = (storeName: string) =>
   `ClassProperty > CallExpression:has(Identifier[name='createEffect']) CallExpression > MemberExpression:has(Identifier[name='dispatch']):has(MemberExpression > Identifier[name='${storeName}'])` as const
 
+export function metadataProperty(key: RegExp): string
+export function metadataProperty<TKey extends string>(
+  key: TKey,
+): `Property:matches([key.name=${TKey}][computed=false], [key.value=${TKey}], [key.quasis.0.value.raw=${TKey}])`
+export function metadataProperty(key: RegExp | string): string {
+  return `Property:matches([key.name=${key}][computed=false], [key.value=${key}], [key.quasis.0.value.raw=${key}])`
+}
+
 export const injectedStore = `MethodDefinition[kind='constructor'] Identifier[typeAnnotation.typeAnnotation.typeName.name='Store']`
 export const typedStore = `MethodDefinition[kind='constructor'] Identifier>TSTypeAnnotation>TSTypeReference[typeName.name='Store'][typeParameters.params]`
 
@@ -36,14 +44,6 @@ export const effectsInNgModuleImports =
 
 export const effectsInNgModuleProviders =
   `${ngModuleProviders} Identifier` as const
-
-export function metadataProperty(key: RegExp): string
-export function metadataProperty<TKey extends string>(
-  key: TKey,
-): `Property:matches([key.name=${TKey}][computed=false], [key.value=${TKey}], [key.quasis.0.value.raw=${TKey}])`
-export function metadataProperty(key: RegExp | string): string {
-  return `Property:matches([key.name=${key}][computed=false], [key.value=${key}], [key.quasis.0.value.raw=${key}])`
-}
 
 export const actionDispatch = (storeName: string) =>
   `ExpressionStatement > CallExpression:matches([callee.object.name='${storeName}'][callee.property.name='dispatch'], [callee.object.object.type='ThisExpression'][callee.object.property.name='${storeName}'][callee.property.name='dispatch'])` as const

--- a/tests/rules/no-reducer-in-key-names.test.ts
+++ b/tests/rules/no-reducer-in-key-names.test.ts
@@ -1,7 +1,9 @@
 import { stripIndent } from 'common-tags'
-import { fromFixture } from 'eslint-etc'
 import path from 'path'
-import rule, { messageId } from '../../src/rules/store/no-reducer-in-key-names'
+import rule, {
+  noReducerInKeyNames,
+  noReducerInKeyNamesSuggest,
+} from '../../src/rules/store/no-reducer-in-key-names'
 import { ruleTester } from '../utils'
 
 ruleTester().run(path.parse(__filename).name, rule, {
@@ -44,54 +46,177 @@ ruleTester().run(path.parse(__filename).name, rule, {
     };`,
   ],
   invalid: [
-    fromFixture(
-      stripIndent`
+    {
+      code: stripIndent`
         @NgModule({
           imports: [
             StoreModule.forRoot({
               feeReducer,
-              ~~~~~~~~~~                        [${messageId}]
-              fieReducer: fie,
-              ~~~~~~~~~~                        [${messageId}]
-              'fooReducer': foo,
-              ~~~~~~~~~~~~                      [${messageId}]
-              FoeReducer: FoeReducer,
-              ~~~~~~~~~~                        [${messageId}]
             }),
           ],
         })
         export class AppModule {}`,
-    ),
-    fromFixture(
-      stripIndent`
+      errors: [
+        {
+          column: 7,
+          endColumn: 17,
+          line: 4,
+          messageId: noReducerInKeyNames,
+          suggestions: [
+            {
+              messageId: noReducerInKeyNamesSuggest,
+              output: stripIndent`
+                @NgModule({
+                  imports: [
+                    StoreModule.forRoot({
+                      fee,
+                    }),
+                  ],
+                })
+                export class AppModule {}`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: stripIndent`
         @NgModule({
           imports: [
             StoreModule.forFeature({
-              feeReducer,
-              ~~~~~~~~~~                        [${messageId}]
-              fieReducer: fie,
-              ~~~~~~~~~~                        [${messageId}]
               'fooReducer': foo,
-              ~~~~~~~~~~~~                      [${messageId}]
-              ['FoeReducer']: FoeReducer,
-               ~~~~~~~~~~~~                     [${messageId}]
+              FoeReducer: FoeReducer,
             }),
           ],
         })
         export class AppModule {}`,
-    ),
-    fromFixture(
-      stripIndent`
+      errors: [
+        {
+          column: 7,
+          endColumn: 19,
+          line: 4,
+          messageId: noReducerInKeyNames,
+          suggestions: [
+            {
+              messageId: noReducerInKeyNamesSuggest,
+              output: stripIndent`
+                @NgModule({
+                  imports: [
+                    StoreModule.forFeature({
+                      'foo': foo,
+                      FoeReducer: FoeReducer,
+                    }),
+                  ],
+                })
+                export class AppModule {}`,
+            },
+          ],
+        },
+        {
+          column: 7,
+          endColumn: 17,
+          line: 5,
+          messageId: noReducerInKeyNames,
+          suggestions: [
+            {
+              messageId: noReducerInKeyNamesSuggest,
+              output: stripIndent`
+                @NgModule({
+                  imports: [
+                    StoreModule.forFeature({
+                      'fooReducer': foo,
+                      Foe: FoeReducer,
+                    }),
+                  ],
+                })
+                export class AppModule {}`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: stripIndent`
         export const reducers: ActionReducerMap<AppState> = {
           feeReducer,
-          ~~~~~~~~~~                          [${messageId}]
-          fieReducer: fie,
-          ~~~~~~~~~~                          [${messageId}]
-          'fooReducer': foo,
-          ~~~~~~~~~~~~                        [${messageId}]
-          [\`FoeReducer\`]: fromFoe.reducer,
-           ~~~~~~~~~~~~                       [${messageId}]
+          'fieReducer': fie,
+          ['fooReducerName']: foo,
+          [\`ReducerFoe\`]: FoeReducer,
         };`,
-    ),
+      errors: [
+        {
+          column: 3,
+          endColumn: 13,
+          line: 2,
+          messageId: noReducerInKeyNames,
+          suggestions: [
+            {
+              messageId: noReducerInKeyNamesSuggest,
+              output: stripIndent`
+                export const reducers: ActionReducerMap<AppState> = {
+                  fee,
+                  'fieReducer': fie,
+                  ['fooReducerName']: foo,
+                  [\`ReducerFoe\`]: FoeReducer,
+                };`,
+            },
+          ],
+        },
+        {
+          column: 3,
+          endColumn: 15,
+          line: 3,
+          messageId: noReducerInKeyNames,
+          suggestions: [
+            {
+              messageId: noReducerInKeyNamesSuggest,
+              output: stripIndent`
+                export const reducers: ActionReducerMap<AppState> = {
+                  feeReducer,
+                  'fie': fie,
+                  ['fooReducerName']: foo,
+                  [\`ReducerFoe\`]: FoeReducer,
+                };`,
+            },
+          ],
+        },
+        {
+          column: 4,
+          endColumn: 20,
+          line: 4,
+          messageId: noReducerInKeyNames,
+          suggestions: [
+            {
+              messageId: noReducerInKeyNamesSuggest,
+              output: stripIndent`
+                export const reducers: ActionReducerMap<AppState> = {
+                  feeReducer,
+                  'fieReducer': fie,
+                  ['fooName']: foo,
+                  [\`ReducerFoe\`]: FoeReducer,
+                };`,
+            },
+          ],
+        },
+        {
+          column: 4,
+          endColumn: 16,
+          line: 5,
+          messageId: noReducerInKeyNames,
+          suggestions: [
+            {
+              messageId: noReducerInKeyNamesSuggest,
+              output: stripIndent`
+                export const reducers: ActionReducerMap<AppState> = {
+                  feeReducer,
+                  'fieReducer': fie,
+                  ['fooReducerName']: foo,
+                  [\`Foe\`]: FoeReducer,
+                };`,
+            },
+          ],
+        },
+      ],
+    },
   ],
 })


### PR DESCRIPTION
Part of #179.

In addition to adding the suggestion, it fixes a bug introduced by #188. Until then, all `reducers` that contained the word "reducer" would be reported, regardless of where it was inserted. After that, it considered incorrect only the `reducers` that ended with the word "reducer". Unfortunately we didn't have tests that covered this, which is no longer the case now.