### PR TITLE
refactor(no-typed-global-store): remove outdated comment

### DIFF
--- a/src/rules/store/no-typed-global-store.ts
+++ b/src/rules/store/no-typed-global-store.ts
@@ -36,7 +36,6 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
         typeParameters: TSESTree.TSTypeParameterInstantiation
       }) {
         context.report({
-          // TODO: Turn it into a fix once https://github.com/ngrx/platform/issues/2780 is fixed.
           suggest: [
             {
               fix: (fixer) => fixer.remove(typeParameters),


### PR DESCRIPTION
When we merged #71, we added this comment, but now the issue is closed and it's still not (and I don't think it ever is) safe to offer a fix to this.