### PR TITLE
refactor: organize `context.report` keys

### DIFF
--- a/src/rules/effects/no-effect-decorator-and-creator.ts
+++ b/src/rules/effects/no-effect-decorator-and-creator.ts
@@ -59,6 +59,8 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
         )
 
         context.report({
+          node: node.key,
+          messageId: noEffectDecoratorAndCreator,
           ...(hasDecoratorArgument
             ? {
                 // In this case where the argument to the `@Effect({...})`
@@ -68,17 +70,15 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
                 // would be quite costly.
                 suggest: [
                   {
+                    messageId: noEffectDecoratorAndCreatorSuggest,
                     fix: (fixer) =>
                       getFixes(node, sourceCode, fixer, decorator),
-                    messageId: noEffectDecoratorAndCreatorSuggest,
                   },
                 ],
               }
             : {
                 fix: (fixer) => getFixes(node, sourceCode, fixer, decorator),
               }),
-          node: node.key,
-          messageId: noEffectDecoratorAndCreator,
         })
       },
     }

--- a/src/rules/effects/no-effect-decorator.ts
+++ b/src/rules/effects/no-effect-decorator.ts
@@ -54,18 +54,18 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
           node.parent.value.callee.name === createEffect
 
         context.report({
+          node,
+          messageId: noEffectDecorator,
           ...(isUsingEffectCreator
             ? {
                 suggest: [
                   {
-                    fix: (fixer) => fixer.remove(node),
                     messageId: noEffectDecoratorSuggest,
+                    fix: (fixer) => fixer.remove(node),
                   },
                 ],
               }
             : { fix: (fixer) => getFixes(node, sourceCode, fixer) }),
-          node,
-          messageId: noEffectDecorator,
         })
       },
     }

--- a/src/rules/store/no-multiple-global-stores.ts
+++ b/src/rules/store/no-multiple-global-stores.ts
@@ -56,8 +56,8 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
             messageId: noMultipleGlobalStores,
             suggest: [
               {
-                fix: (fixer) => getFixes(sourceCode, fixer, node),
                 messageId: noMultipleGlobalStoresSuggest,
+                fix: (fixer) => getFixes(sourceCode, fixer, node),
               },
             ],
           })

--- a/src/rules/store/no-reducer-in-key-names.ts
+++ b/src/rules/store/no-reducer-in-key-names.ts
@@ -46,14 +46,14 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
           messageId: noReducerInKeyNames,
           suggest: [
             {
+              messageId: noReducerInKeyNamesSuggest,
               fix: (fixer) => {
                 const keyName = getRawText(key)
                 return fixer.replaceText(
                   key,
-                  keyName.replace(RegExp(reducerKeyword, 'i'), ''),
+                  keyName.replace(new RegExp(reducerKeyword, 'i'), ''),
                 )
               },
-              messageId: noReducerInKeyNamesSuggest,
             },
           ],
         })

--- a/src/rules/store/no-typed-global-store.ts
+++ b/src/rules/store/no-typed-global-store.ts
@@ -36,14 +36,14 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
         typeParameters: TSESTree.TSTypeParameterInstantiation
       }) {
         context.report({
-          suggest: [
-            {
-              fix: (fixer) => fixer.remove(typeParameters),
-              messageId: noTypedStoreSuggest,
-            },
-          ],
           node: typeParameters,
           messageId,
+          suggest: [
+            {
+              messageId: noTypedStoreSuggest,
+              fix: (fixer) => fixer.remove(typeParameters),
+            },
+          ],
         })
       },
     }

--- a/src/rules/store/on-function-explicit-return-type.ts
+++ b/src/rules/store/on-function-explicit-return-type.ts
@@ -41,8 +41,8 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
           messageId: onFunctionExplicitReturnType,
           suggest: [
             {
-              fix: (fixer) => getFixes(node, sourceCode, fixer),
               messageId: onFunctionExplicitReturnTypeSuggest,
+              fix: (fixer) => getFixes(node, sourceCode, fixer),
             },
           ],
         })

--- a/src/rules/store/prefer-inline-action-props.ts
+++ b/src/rules/store/prefer-inline-action-props.ts
@@ -33,17 +33,17 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
     return {
       [actionCreatorPropsComputed](node: TSESTree.TSTypeReference) {
         context.report({
+          node,
+          messageId: preferInlineActionProps,
           suggest: [
             {
+              messageId: preferInlineActionPropsSuggest,
               fix: (fixer) => [
                 fixer.insertTextBefore(node, '{name: '),
                 fixer.insertTextAfter(node, '}'),
               ],
-              messageId: preferInlineActionPropsSuggest,
             },
           ],
-          node,
-          messageId: preferInlineActionProps,
         })
       },
     }

--- a/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
+++ b/src/rules/store/prefer-one-generic-in-create-for-feature-selector.ts
@@ -44,6 +44,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
           messageId: preferOneGenericInCreateForFeatureSelector,
           suggest: [
             {
+              messageId: preferOneGenericInCreateForFeatureSelectorSuggest,
               fix: (fixer) => {
                 const [globalState] = node.params
                 const nextToken = sourceCode.getTokenAfter(globalState)
@@ -52,7 +53,6 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
                   nextToken?.range[1] ?? globalState.range[1] + 1,
                 ])
               },
-              messageId: preferOneGenericInCreateForFeatureSelectorSuggest,
             },
           ],
         })

--- a/src/rules/store/prefix-selectors-with-select.ts
+++ b/src/rules/store/prefix-selectors-with-select.ts
@@ -45,19 +45,18 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
               column: id.typeAnnotation?.range[0] ?? id.range[1],
             },
           },
-          node: id,
           messageId: prefixSelectorsWithSelect,
           suggest: [
             {
               messageId: prefixSelectorsWithSelectSuggest,
+              data: {
+                name: suggestedName,
+              },
               fix: (fixer) =>
                 fixer.replaceTextRange(
                   [id.range[0], id.typeAnnotation?.range[0] ?? id.range[1]],
                   suggestedName,
                 ),
-              data: {
-                name: suggestedName,
-              },
             },
           ],
         })
@@ -70,7 +69,7 @@ function getSuggestedName(name: string) {
   const selectWord = 'select'
   // Ex: 'selectfeature' => 'selectFeature'
   let possibleReplacedName = name.replace(
-    RegExp(`^${selectWord}(.+)`),
+    new RegExp(`^${selectWord}(.+)`),
     (_, lowercasedWord: string) => {
       return `${selectWord}${capitalize(lowercasedWord)}`
     },

--- a/src/rules/store/use-consistent-global-store-name.ts
+++ b/src/rules/store/use-consistent-global-store-name.ts
@@ -59,12 +59,12 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
           suggest: [
             {
               messageId: useConsistentGlobalStoreNameSuggest,
+              data,
               fix: (fixer) =>
                 fixer.replaceTextRange(
                   [range[0], typeAnnotation.range[0]],
                   storeName,
                 ),
-              data,
             },
           ],
         })


### PR DESCRIPTION
Instead of putting `node` + `messageId` in the end, it puts in the begin, which makes it much more readable IMHO.