### PR TITLE
test(no-reducer-in-key-names): ensure the correct behavior for hyphenated keys

### DIFF
--- a/src/rules/store/no-reducer-in-key-names.ts
+++ b/src/rules/store/no-reducer-in-key-names.ts
@@ -49,6 +49,11 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
               messageId: noReducerInKeyNamesSuggest,
               fix: (fixer) => {
                 const keyName = getRawText(key)
+
+                if (!keyName) {
+                  return null
+                }
+
                 return fixer.replaceText(
                   key,
                   keyName.replace(new RegExp(reducerKeyword, 'i'), ''),

--- a/src/utils/helper-functions/utils.ts
+++ b/src/utils/helper-functions/utils.ts
@@ -279,7 +279,7 @@ export function getDecorator(
   )
 }
 
-export function getRawText(node: TSESTree.Node): string {
+export function getRawText(node: TSESTree.Node): string | null {
   if (isIdentifier(node)) {
     return node.name
   }
@@ -300,7 +300,7 @@ export function getRawText(node: TSESTree.Node): string {
     return `\`${node.quasis[0].value.raw}\``
   }
 
-  throw Error(`Unexpected \`node.type\` provided: ${node.type}`)
+  return null
 }
 
 export function capitalize<T extends string>(text: T): Capitalize<T> {

--- a/tests/rules/no-reducer-in-key-names.test.ts
+++ b/tests/rules/no-reducer-in-key-names.test.ts
@@ -84,7 +84,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
         @NgModule({
           imports: [
             StoreModule.forFeature({
-              'fooReducer': foo,
+              'foo-reducer': foo,
               FoeReducer: FoeReducer,
             }),
           ],
@@ -93,7 +93,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
       errors: [
         {
           column: 7,
-          endColumn: 19,
+          endColumn: 20,
           line: 4,
           messageId: noReducerInKeyNames,
           suggestions: [
@@ -103,7 +103,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
                 @NgModule({
                   imports: [
                     StoreModule.forFeature({
-                      'foo': foo,
+                      'foo-': foo,
                       FoeReducer: FoeReducer,
                     }),
                   ],
@@ -124,7 +124,7 @@ ruleTester().run(path.parse(__filename).name, rule, {
                 @NgModule({
                   imports: [
                     StoreModule.forFeature({
-                      'fooReducer': foo,
+                      'foo-reducer': foo,
                       Foe: FoeReducer,
                     }),
                   ],


### PR DESCRIPTION
Instead of using our own implementation, it uses `getPropertyName` from `@typescript-eslint`.