### PR TITLE
fix(prefer-effect-callback-in-block-statement): handle all kinds of `createEffect` properly

### DIFF
--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -1,7 +1,5 @@
 export const effectCreator = `ClassProperty[value.callee.name='createEffect']`
-export const createEffectExpression = `ClassProperty > CallExpression[callee.name='createEffect']`
-export const createEffectFunction =
-  `${createEffectExpression} > ArrowFunctionExpression` as const
+export const createEffectExpression = `CallExpression[callee.name='createEffect']`
 
 export const effectDecorator = `Decorator[expression.callee.name='Effect']`
 export const classPropertyWithEffectDecorator =


### PR DESCRIPTION
Part of #242, this fixes the following issues:

- [x] handle `createEffect` in any place, not only in `ClassProperty`;
- [x] handle parametrized `createEffect`;
- [x] correct the fix if `createEffect#body` is parenthesized. Currently `createEffect(() => (...)` become `createEffect(() => ({ ... })`.