### PR TITLE
test: ensure the tests cover `createEffect` properly

### DIFF
--- a/tests/rules/avoid-cyclic-effects.test.ts
+++ b/tests/rules/avoid-cyclic-effects.test.ts
@@ -107,16 +107,18 @@ ruleTester().run(path.parse(__filename).name, rule, {
     `
       ${setup}
       class Effect {
-        foo$ = createEffect(() =>
-          this.actions$.pipe(
-            ofType(genericFoo),
-            map(() => genericBar()),
-          ),
-        )
+        foo$: Observable<unknown>
 
         constructor(
           private actions$: Actions,
-        ) {}
+        ) {
+          this.foo$ = createEffect(() =>
+            this.actions$.pipe(
+              ofType(genericFoo),
+              map(() => genericBar()),
+            ),
+          )
+        }
       }
     `,
     // https://github.com/timdeschryver/eslint-plugin-ngrx/issues/223
@@ -205,32 +207,36 @@ ruleTester().run(path.parse(__filename).name, rule, {
     fromFixture(stripIndent`
       ${setup}
       class Effect {
-        foo$ = createEffect(() =>
-          this.actions$.pipe(
-          ~~~~~~~~~~~~~~~~~~ [${messageId}]
-            ofType(fromFoo.foo),
-            tap(() => alert('hi'))
-          ),
+        foo$ = createEffect(
+          () =>
+            ({ debounce = 100 } = {}) =>
+              debounce
+                ? this.actions$.pipe(
+                  ~~~~~~~~~~~~~~~~~~ [${messageId}]
+                    ofType(fromFoo.foo),
+                    tap(() => alert('hi')),
+                  )
+                : this.actions$.pipe(),
         )
 
-        constructor(
-          private actions$: Actions,
-        ) {}
+        constructor(private actions$: Actions) {}
       }
     `),
     fromFixture(stripIndent`
       ${setup}
       class Effect {
-        foo$ = createEffect(() =>
-          this.actions$.pipe(
-          ~~~~~~~~~~~~~~~~~~ [${messageId}]
-            ofType(genericFoo),
-          ),
-        )
+        foo$: Observable<unknown>
 
         constructor(
           private actions$: Actions,
-        ) {}
+        ) {
+          this.foo$ = createEffect(() =>
+            this.actions$.pipe(
+            ~~~~~~~~~~~~~~~~~~ [${messageId}]
+              ofType(genericFoo),
+            ),
+          )
+        }
       }
     `),
     // https://github.com/timdeschryver/eslint-plugin-ngrx/issues/223

--- a/tests/rules/updater-explicit-return-type.test.ts
+++ b/tests/rules/updater-explicit-return-type.test.ts
@@ -86,8 +86,8 @@ ruleTester().run(path.parse(__filename).name, rule, {
             super({movies: []});
           }
 
-          readonly addMovie = this.updater<Movie>((state, movie) => ({ movies: [...state.movies, movie] }));
-                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   [${messageId}]
+          readonly addMovie = this.updater<Movie | null>((state, movie) => movie ? ({ movies: [...state.movies, movie] }) : ({ movies }));
+                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   [${messageId}]
         }
       `,
     ),


### PR DESCRIPTION
Part of #242, this ensures we cover `createEffect` in non `ClassProperties`.