### PR TITLE
fix: handle `ClassDeclaration` without `id` properly

### DIFF
--- a/src/rules/effects/use-effects-lifecycle-interface.ts
+++ b/src/rules/effects/use-effects-lifecycle-interface.ts
@@ -6,6 +6,7 @@ import {
   docsUrl,
   getImplementsSchemaFixer,
   getImportAddFix,
+  getLocOrNode,
   NGRX_MODULE_PATHS,
 } from '../../utils'
 
@@ -45,7 +46,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
           node: TSESTree.ClassDeclaration,
         ) {
           context.report({
-            node: node.id ?? node,
+            ...getLocOrNode(node),
             messageId,
             data: {
               interfaceName,
@@ -71,10 +72,13 @@ function getFixes(
   node: TSESTree.ClassDeclaration,
   interfaceName: string,
 ): readonly TSESLint.RuleFix[] {
-  const { implementsNodeReplace, implementsTextReplace } =
+  const { classBodyOrLastInterfaceRange, implementsInterfaceText } =
     getImplementsSchemaFixer(node, interfaceName)
   return [
-    fixer.insertTextAfter(implementsNodeReplace, implementsTextReplace),
+    fixer.insertTextAfterRange(
+      classBodyOrLastInterfaceRange,
+      implementsInterfaceText,
+    ),
   ].concat(
     getImportAddFix({
       compatibleWithTypeOnlyImport: true,

--- a/src/rules/store/prefer-action-creator.ts
+++ b/src/rules/store/prefer-action-creator.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils'
 import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 import path from 'path'
-import { docsUrl } from '../../utils'
+import { classImplements, docsUrl } from '../../utils'
 
 export const messageId = 'preferActionCreator'
 export type MessageIds = typeof messageId
@@ -27,7 +27,9 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      [`ClassDeclaration:has(TSClassImplements:matches([expression.name='Action'], [expression.property.name='Action'])):has(ClassProperty[key.name='type'])`](
+      [`ClassDeclaration:has(${classImplements(
+        'Action',
+      )}):has(ClassProperty[key.name='type'])`](
         node: TSESTree.ClassDeclaration,
       ) {
         context.report({

--- a/src/utils/selectors/index.ts
+++ b/src/utils/selectors/index.ts
@@ -66,6 +66,9 @@ export const dispatchInEffects = (name: RegExp | string) =>
     name,
   )} > MemberExpression:has(Identifier[name=${name}])` as const
 
+export const classImplements = (interfaceName: string) =>
+  `TSClassImplements:matches([expression.name='${interfaceName}'], [expression.property.name='${interfaceName}'])` as const
+
 export const createReducer = `CallExpression[callee.name='createReducer']`
 
 export const onFunctionWithoutType =

--- a/tests/rules/use-effects-lifecycle-interface.test.ts
+++ b/tests/rules/use-effects-lifecycle-interface.test.ts
@@ -1,4 +1,3 @@
-import { stripIndent } from 'common-tags'
 import { fromFixture } from 'eslint-etc'
 import path from 'path'
 import rule, {
@@ -9,150 +8,134 @@ import { ruleTester } from '../utils'
 ruleTester().run(path.parse(__filename).name, rule, {
   valid: [
     `
-      class Foo {}
-    `,
+class Ok {}`,
     `
-      class UserEffects implements OnInitEffects {
-        ngrxOnInitEffects(): Action {
-          return { type: '[UserEffects]: Init' }
-        }
-      }
-    `,
+class Ok1 implements OnInitEffects {
+  ngrxOnInitEffects(): Action {
+    return { type: '[UserEffects]: Init' }
+  }
+}`,
     `
-      export class UserEffects implements OnRunEffects {
-        constructor(private actions$: Actions) {}
-        updateUser$ = createEffect(() =>
-            this.actions$.pipe(
-              ofType('UPDATE_USER'),
-              tap(action => {
-                console.log(action)
-              })
-            ),
-          { dispatch: false })
-        ngrxOnRunEffects(resolvedEffects$: Observable<EffectNotification>) {
-          return this.actions$.pipe(
-            ofType('LOGGED_IN'),
-            exhaustMap(() =>
-              resolvedEffects$.pipe(
-                takeUntil(this.actions$.pipe(ofType('LOGGED_OUT')))
-              )
-            )
-          )
-        }
-      }
-    `,
+class Ok2 implements OnRunEffects {
+  constructor(private readonly actions$: Actions) {}
+
+  ngrxOnRunEffects(resolvedEffects$: Observable<EffectNotification>) {
+    return this.actions$.pipe(
+      ofType(AuthActions.loggedIn),
+      exhaustMap(() =>
+        resolvedEffects$.pipe(
+          takeUntil(this.actions$.pipe(ofType('LOGGED_OUT')))
+        )
+      )
+    )
+  }
+}`,
     `
-      class EffectWithIdentifier implements OnIdentifyEffects {
-        constructor(private effectIdentifier: string) {}
-        ngrxOnIdentifyEffects() {
-          return this.effectIdentifier
-        }
-      }
-    `,
+class Ok3 implements OnIdentifyEffects {
+  constructor(private effectIdentifier: string) {}
+
+  ngrxOnIdentifyEffects() {
+    return this.effectIdentifier
+  }
+}`,
     `
-      class UserEffects implements ngrx.OnInitEffects, OnIdentifyEffects {
-        ngrxOnInitEffects(): Action {
-          return { type: '[UserEffects]: Init' }
-        }
-        ngrxOnIdentifyEffects(): string {
-          return ''
-        }
-      }
-    `,
+class Ok4 implements ngrx.OnInitEffects, OnIdentifyEffects {
+  ngrxOnInitEffects() {}
+
+  ngrxOnIdentifyEffects() {}
+}`,
   ],
   invalid: [
     fromFixture(
-      stripIndent`
-        class UserEffects {
-          ngrxOnInitEffects() {}
-          ~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
-        }
-      `,
+      `
+class NotOk {
+      ~~~~~ [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
+  ngrxOnInitEffects() {}
+}`,
       {
-        output: stripIndent`
-          import { OnInitEffects } from '@ngrx/effects';
-          class UserEffects implements OnInitEffects {
-            ngrxOnInitEffects() {}
-          }
-        `,
+        output: `import { OnInitEffects } from '@ngrx/effects';
+
+class NotOk implements OnInitEffects {
+  ngrxOnInitEffects() {}
+}`,
       },
     ),
     fromFixture(
-      stripIndent`
-        import Effects from '@ngrx/effects'
-        class UserEffects {
-          ngrxOnIdentifyEffects() {}
-          ~~~~~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
-        }
-      `,
+      `
+import Effects from '@ngrx/effects'
+
+class NotOk1 {
+      ~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
+  ngrxOnIdentifyEffects() {}
+}`,
       {
-        output: stripIndent`
-          import Effects, { OnIdentifyEffects } from '@ngrx/effects'
-          class UserEffects implements OnIdentifyEffects {
-            ngrxOnIdentifyEffects() {}
-          }
-        `,
+        output: `
+import Effects, { OnIdentifyEffects } from '@ngrx/effects'
+
+class NotOk1 implements OnIdentifyEffects {
+  ngrxOnIdentifyEffects() {}
+}`,
       },
     ),
     fromFixture(
-      stripIndent`
-        import { Injectable } from '@angular/core'
-        class UserEffects {
-          ngrxOnRunEffects() {}
-          ~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnRunEffects", "methodName": "ngrxOnRunEffects" }]
-        }
-      `,
+      `
+import { Injectable } from '@angular/core'
+
+class NotOk2 {
+      ~~~~~~ [${messageId} { "interfaceName": "OnRunEffects", "methodName": "ngrxOnRunEffects" }]
+  ngrxOnRunEffects() {}
+}`,
       {
-        output: stripIndent`
-          import { OnRunEffects } from '@ngrx/effects';
-          import { Injectable } from '@angular/core'
-          class UserEffects implements OnRunEffects {
-            ngrxOnRunEffects() {}
-          }
-        `,
+        output: `import { OnRunEffects } from '@ngrx/effects';
+
+import { Injectable } from '@angular/core'
+
+class NotOk2 implements OnRunEffects {
+  ngrxOnRunEffects() {}
+}`,
       },
     ),
     fromFixture(
-      stripIndent`
-        import * as ngrx from '@ngrx/effects'
-        class UserEffects {
-          ngrxOnInitEffects() {}
-          ~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
-        }
-      `,
+      `
+import * as ngrx from '@ngrx/effects'
+
+class NotOk3 {
+      ~~~~~~ [${messageId} { "interfaceName": "OnInitEffects", "methodName": "ngrxOnInitEffects" }]
+  ngrxOnInitEffects() {}
+}`,
       {
-        output: stripIndent`
-          import { OnInitEffects } from '@ngrx/effects';
-          import * as ngrx from '@ngrx/effects'
-          class UserEffects implements OnInitEffects {
-            ngrxOnInitEffects() {}
-          }
-        `,
+        output: `import { OnInitEffects } from '@ngrx/effects';
+
+import * as ngrx from '@ngrx/effects'
+
+class NotOk3 implements OnInitEffects {
+  ngrxOnInitEffects() {}
+}`,
       },
     ),
     fromFixture(
-      stripIndent`
-        import type { OnInitEffects, OnRunEffects } from '@ngrx/effects'
-        class UserEffects implements OnInitEffects, OnRunEffects {
-          ngrxOnInitEffects() {}
+      `
+import type { OnInitEffects, OnRunEffects } from '@ngrx/effects'
 
-          ngrxOnIdentifyEffects() {}
-          ~~~~~~~~~~~~~~~~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
+class NotOk4 implements OnInitEffects, OnRunEffects {
+      ~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
+  ngrxOnInitEffects() {}
 
-          ngrxOnRunEffects() {}
-        }
-      `,
+  ngrxOnIdentifyEffects() {}
+
+  ngrxOnRunEffects() {}
+}`,
       {
-        output: stripIndent`
-          import type { OnInitEffects, OnRunEffects, OnIdentifyEffects } from '@ngrx/effects'
-          class UserEffects implements OnInitEffects, OnRunEffects, OnIdentifyEffects {
-            ngrxOnInitEffects() {}
+        output: `
+import type { OnInitEffects, OnRunEffects, OnIdentifyEffects } from '@ngrx/effects'
 
-            ngrxOnIdentifyEffects() {}
+class NotOk4 implements OnInitEffects, OnRunEffects, OnIdentifyEffects {
+  ngrxOnInitEffects() {}
 
-            ngrxOnRunEffects() {}
-          }
-        `,
+  ngrxOnIdentifyEffects() {}
+
+  ngrxOnRunEffects() {}
+}`,
       },
     ),
   ],

--- a/tests/rules/use-effects-lifecycle-interface.test.ts
+++ b/tests/rules/use-effects-lifecycle-interface.test.ts
@@ -138,5 +138,36 @@ class NotOk4 implements OnInitEffects, OnRunEffects, OnIdentifyEffects {
 }`,
       },
     ),
+    fromFixture(
+      `
+import type { OnInitEffects, OnRunEffects } from '@ngrx/effects'
+
+export default class NotOk5 implements OnDestroy {
+                     ~~~~~~ [${messageId} { "interfaceName": "OnRunEffects", "methodName": "ngrxOnRunEffects" }]
+  ngrxOnRunEffects() {}
+}`,
+      {
+        output: `
+import type { OnInitEffects, OnRunEffects } from '@ngrx/effects'
+
+export default class NotOk5 implements OnDestroy, OnRunEffects {
+  ngrxOnRunEffects() {}
+}`,
+      },
+    ),
+    fromFixture(
+      `
+export default class {
+               ~~~~~~ [${messageId} { "interfaceName": "OnIdentifyEffects", "methodName": "ngrxOnIdentifyEffects" }]
+  ngrxOnIdentifyEffects() {}
+}`,
+      {
+        output: `import { OnIdentifyEffects } from '@ngrx/effects';
+
+export default class  implements OnIdentifyEffects{
+  ngrxOnIdentifyEffects() {}
+}`,
+      },
+    ),
   ],
 })


### PR DESCRIPTION
**refactor: separate `TSClassImplements` to reuse**:

it extracts the `TSClassImplements` selector from the `prefer-action-creator` to `src/utils/selectors/` in order to reuse.

**refactor: report `ClassDeclaration[id]` instead of `MethodDefinition[key]`**:

IMHO, it makes more sense if we report `ClassDeclaration` instead of `MethodDefinition`, because from a technical point of view, we should indicate that the `class` should implement an `interface` and not that the `method` has "error".

**fix: handle `ClassDeclaration` without `id` properly**:

In fact, the fix has always been broken for `default class {`, since we had a typecast in the `id` (`id as TSETree.Identifier`) where the `id` could be in fact `null`.