### PR TITLE
fix(prefix-selectors-with-select): handle all kinds of IdentifierName properly

### DIFF
--- a/src/rules/store/prefix-selectors-with-select.ts
+++ b/src/rules/store/prefix-selectors-with-select.ts
@@ -33,7 +33,7 @@ export default ESLintUtils.RuleCreator(docsUrl)<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     return {
-      'VariableDeclarator[id.name!=/^select[A-Z][a-zA-Z]+$/]:matches([id.typeAnnotation.typeAnnotation.typeName.name=/^MemoizedSelector(WithProps)?$/], :has(CallExpression[callee.name=/^(create(Feature)?Selector|createSelectorFactory)$/]))'({
+      'VariableDeclarator[id.name!=/^select.+$/]:matches([id.typeAnnotation.typeAnnotation.typeName.name=/^MemoizedSelector(WithProps)?$/], :has(CallExpression[callee.name=/^(create(Feature)?Selector|createSelectorFactory)$/]))'({
         id,
       }: TSESTree.VariableDeclarator & { id: TSESTree.Identifier }) {
         const suggestedName = getSuggestedName(id.name)

--- a/tests/rules/prefix-selectors-with-select.test.ts
+++ b/tests/rules/prefix-selectors-with-select.test.ts
@@ -31,6 +31,8 @@ const valid: RunTests['valid'] = [
     export const selectThing = (id: string) => createSelector(selectThings, things => things[id])`,
   `
     export const selectFeature = createSelectorFactory(factoryFn)`,
+  `
+    export const selectFeature1 = createSelectorFactory(factoryFn)`,
 ]
 
 const invalid: RunTests['invalid'] = [
@@ -120,24 +122,6 @@ const invalid: RunTests['invalid'] = [
           },
           output: stripIndent`
             export const selectFeature = createFeatureSelector<AppState, FeatureState>(featureKey)`,
-        },
-      ],
-    },
-  ),
-  fromFixture(
-    stripIndent`
-      export const selectfeature = createSelector((state: AppState) => state.feature)
-                   ~~~~~~~~~~~~~ [${prefixSelectorsWithSelect}]
-      `,
-    {
-      suggestions: [
-        {
-          messageId: prefixSelectorsWithSelectSuggest,
-          data: {
-            name: 'selectFeature',
-          },
-          output: stripIndent`
-            export const selectFeature = createSelector((state: AppState) => state.feature)`,
         },
       ],
     },


### PR DESCRIPTION
As defined by ECMAScript spec (https://tc39.es/ecma262/#prod-IdentifierName), an identifier can contain
- `UnicodeIDContinue` (any Unicode code point with the Unicode property _ID_Continue_),
- `$`,
- `U+200C` (ZERO WIDTH NON-JOINER, \<ZWNJ\>),
- `U+200D` (ZERO WIDTH JOINER, \<ZWJ\>)
- `\ UnicodeEscapeSequence`

and must start with one of
- `UnicodeIDStart` (any Unicode code point with the Unicode property _ID_Start_),
- `$`,
- `_`

Due to the complexity of this specification and because I believe that this rule should not assume the style of the code it corrects (if using camelCase or snake_case, for example), I have removed the test `export const selectfeature = createSelector ((state: AppState) => state.feature)`. As I say, in my opinion this line of code should not fail, at least with this specific rule.

In addition to this, a test is added with the case of failure that has motivated this RP.

I remain at the disposal of any question.

PS: this is my first contribution to public software :smile:, don't lynch me :confused:...

Resolves #261