### PR TITLE
fix: 🐛 downgrade required typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "eslint": ">=8.0.0",
-    "typescript": ">=4.4.0"
+    "typescript": ">=4.3.5"
   },
   "devDependencies": {
     "@ngrx/effects": "^13.0.1",


### PR DESCRIPTION
This will allow projects using Angular 12 and npm 8 to install dependencies without the --force flag.